### PR TITLE
Fix python bindings

### DIFF
--- a/neurolabi/gui/CMakeLists.txt
+++ b/neurolabi/gui/CMakeLists.txt
@@ -2,6 +2,12 @@ cmake_minimum_required(VERSION 2.8)
 
 project (neutube)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++11 ")
+
+if (APPLE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+endif()
+
 add_custom_target(
   neutube
   DEPENDS neuTube

--- a/neurolabi/gui/CMakeLists_qt.txt
+++ b/neurolabi/gui/CMakeLists_qt.txt
@@ -4,6 +4,12 @@ project (neutube)
 
 find_package (Qt4)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++11 ")
+
+if (APPLE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+endif()
+
 if (QT4_FOUND)
   include ($(QT_USE_FILE))
 

--- a/neurolabi/python/module/Makefile
+++ b/neurolabi/python/module/Makefile
@@ -4,20 +4,32 @@ UNAME := $(shell uname)
 SHARE_FLAG = shared
 ifeq ($(UNAME), Darwin)
   SHARE_FLAG = bundle
+  STDLIB_FLAG = -stdlib=libc++
   #SHARE_FLAG = dynamiclib
   HDF5_FLAG = $(PREFIX)/lib/libhdf5.10.dylib
   #RPATH_FLAG = -install_name @rpath/$(PREFIX)/lib/libhdf5.dylib
 else
   HDF5_FLAG = -lhdf5
+  STDLIB_FLAG = ""
 endif
 
 
 all: _neutube.so
 debug: _neutube_d.so
 
+# On Mac, this command:
+# python3-config --ldflags
+# ...returns a string that includes '-Wl,-stack_size,1000000', which results in an error:
+# ld: -stack_size option can only be used when linking a main executable
+# So, let's get rid of it.
+# (BTW, we're not the only ones with this problem: https://github.com/waf-project/waf/issues/1745#issuecomment-220554258)
+python_ldflags := $(shell python3-config --ldflags \
+				   | python -c "import sys; print(' '.join(filter(lambda s: not 'stack_size' in s, sys.stdin.read().split())))" \
+				   | sed 's/-u [^ ]* [^ ]*//')
+
 define compile_so
         @echo $(PREFIX)
-	g++ -$(SHARE_FLAG) neutube_wrap.o $(RPATH_FLAG) -o $@ -L$(PREFIX)/lib -L../../cpp/lib/build -l$(1) -L../../c/lib -l$(2) -lfftw3 -lfftw3f -lxml2 $(HDF5_FLAG) -ljansson -lm -lz `python-config --ldflags | sed 's/-u [^ ]* [^ ]*//'`
+	$(CXX) -std=c++11 $(STDLIB_FLAG) -$(SHARE_FLAG) neutube_wrap.o $(RPATH_FLAG) -o $@ -L$(PREFIX)/lib -L../../cpp/lib/build -l$(1) -L../../c/lib -l$(2) -lfftw3 -lfftw3f -lxml2 $(HDF5_FLAG) -ljansson -lm -lz $(python_ldflags)
 endef
 
 fix: _neutube.so
@@ -30,8 +42,9 @@ _neutube_d.so: neutube_wrap.o
 	$(call compile_so,neutube,neurolabi_debug)
 	mv $@ _neutube.so
 
+
 neutube_wrap.o: neutube_wrap.cxx
-	g++ -c $< -I../../c -I../../lib/genelib/src -I../../c/include -I../../gui -I../../lib/jansson/include -I../../lib/fftw3/include -fPIC `python-config --cflags`
+	$(CXX) -std=c++11 $(STDLIB_FLAG) -c $< -I../../c -I../../lib/genelib/src -I../../c/include -I../../gui -I../../lib/jansson/include -I../../lib/fftw3/include -fPIC `python3-config --cflags`
 
 neutube_wrap.cxx: $(SOURCE)
 	@which gcc


### PR DESCRIPTION
These changes seem to get the python bindings to build with conda.

- Add `-std=c++11` and `-stdlib=libc++` where necessary
- Explicitly use environment-defined `CXX` and also `python3-config` (since `python-config` doesn't exist in python 3??)
- And make sure `-Wl,-stack_size` is not used
