### PR TITLE
python/cpp: Build enhancements

### DIFF
--- a/neurolabi/cpp/lib/build.sh
+++ b/neurolabi/cpp/lib/build.sh
@@ -13,8 +13,9 @@ if [ ${config:-release} == debug ]
 then
   cmake -DCMAKE_BUILD_TYPE=Debug ..
 else
-  cmake ..
+  cmake -DCMAKE_BUILD_TYPE=Release ..
 fi
 
 THREAD_COUNT=${CPU_COUNT:-3}  # conda-build provides CPU_COUNT
-make -j${THREAD_COUNT} 
+make -j${THREAD_COUNT} VERBOSE=1 
+

--- a/recipe-neutube-python/build.sh
+++ b/recipe-neutube-python/build.sh
@@ -9,7 +9,7 @@ cd neurolabi
 
 # Build the swig bindings
 cd python/module
-make
+make VERBOSE=1
 
 PY_VER=$(python -c "import sys; print('{}.{}'.format(*sys.version_info[:2]))")
 PY_ABIFLAGS=$(python -c "import sys; print('' if sys.version_info.major == 2 else sys.abiflags)")

--- a/recipe-neutube-python/meta.yaml
+++ b/recipe-neutube-python/meta.yaml
@@ -38,6 +38,10 @@ requirements:
     - hdf5    1.8.18
     
 
+test:
+  imports:
+    - neutube
+
 about:
   home: http://github.com/janelia-flyem/NeuTu
   license: GPL


### PR DESCRIPTION
- Ensure c++ files are built in release mode (they weren't, previously -- not sure when that changed)
- Build with `VERBOSE=1`
- Recipe tests that `import neutube` works
