### PR TITLE
Python build enhancements

### DIFF
--- a/neurolabi/cpp/lib/build.sh
+++ b/neurolabi/cpp/lib/build.sh
@@ -17,4 +17,5 @@ else
 fi
 
 THREAD_COUNT=${CPU_COUNT:-3}  # conda-build provides CPU_COUNT
-make -j${THREAD_COUNT} 
+make -j${THREAD_COUNT} VERBOSE=1
+

--- a/neurolabi/cpp/lib/build.sh
+++ b/neurolabi/cpp/lib/build.sh
@@ -13,7 +13,7 @@ if [ ${config:-release} == debug ]
 then
   cmake -DCMAKE_BUILD_TYPE=Debug ..
 else
-  cmake ..
+  cmake -DCMAKE_BUILD_TYPE=Release ..
 fi
 
 THREAD_COUNT=${CPU_COUNT:-3}  # conda-build provides CPU_COUNT

--- a/recipe-neutube-python/build.sh
+++ b/recipe-neutube-python/build.sh
@@ -9,7 +9,7 @@ cd neurolabi
 
 # Build the swig bindings
 cd python/module
-make
+make VERBOSE=1
 
 PY_VER=$(python -c "import sys; print('{}.{}'.format(*sys.version_info[:2]))")
 PY_ABIFLAGS=$(python -c "import sys; print('' if sys.version_info.major == 2 else sys.abiflags)")

--- a/recipe-neutube-python/meta.yaml
+++ b/recipe-neutube-python/meta.yaml
@@ -38,6 +38,10 @@ requirements:
     - hdf5    1.8.18
     
 
+test:
+  imports:
+    - neutube
+
 about:
   home: http://github.com/janelia-flyem/NeuTu
   license: GPL


### PR DESCRIPTION
(The most important change is the first one.  We were building C++ files without `-O3`)

- cpp: Build with `CMAKE_BUILD_TYPE=Release`
- cpp/python: Build with `VERBOSE=1 `
- python: recipe tests that `import neutube`works
