### PR TITLE
Add support for DVID instances whose values are tar archives of meshe…

### DIFF
--- a/neurolabi/gui/dvid/zdviddata.cpp
+++ b/neurolabi/gui/dvid/zdviddata.cpp
@@ -28,6 +28,8 @@ const char* ZDvidData::m_neutuConfigName = "neutu_config";
 const char* ZDvidData::m_labelszName = "labelsz";
 const char* ZDvidData::m_meshName = "meshes";
 const char* ZDvidData::m_sparsevolSizeName = "sparsevol-size";
+const char* ZDvidData::m_meshesTarsName = "meshes_tars";
+
 
 //const char* ZDvidData::m_keyValueTypeName = "keyvalue";
 
@@ -113,6 +115,8 @@ std::string ZDvidData::GetName(ERole role)
     return GetName(ROLE_SPLIT_TASK_KEY) + "_" + "property";
   case ROLE_MESH:
     return m_meshName;
+  case ROLE_MESHES_TARS:
+    return m_meshesTarsName;
   }
 
   return m_emptyName;

--- a/neurolabi/gui/dvid/zdviddata.h
+++ b/neurolabi/gui/dvid/zdviddata.h
@@ -49,7 +49,8 @@ public:
     ROLE_SPLIT_RESULT_KEY,
     ROLE_SPLIT_TASK_PROPERTY_KEY,
     ROLE_SPLIT_RESULT_PROPERTY_KEY,
-    ROLE_MESH
+    ROLE_MESH,
+    ROLE_MESHES_TARS
   };
 
   enum EType {
@@ -114,6 +115,8 @@ private:
   static const char *m_meshName;
   static const char *m_sparsevolSizeName;
   //static const char *m_keyValueTypeName;
+  static const char *m_meshesTarsName;
+
 
   static const char *m_nullName;
   static const char *m_emptyName;

--- a/neurolabi/gui/dvid/zdvidreader.h
+++ b/neurolabi/gui/dvid/zdvidreader.h
@@ -45,6 +45,8 @@ class ZDvidRoi;
 class ZObject3dScanArray;
 class ZMesh;
 
+struct archive;
+
 namespace libdvid{
 class DVIDNodeService;
 class DVIDConnection;
@@ -129,6 +131,14 @@ public:
       uint64_t bodyId, bool canonizing, ZObject3dScan *result);
 
   ZMesh* readMesh(uint64_t bodyId, int zoom);
+
+  /*!
+   * \brief Read meshes from a key-value instance whose values are tar archives of
+   * Draco-compressed meshes
+   */
+  struct archive *readMeshArchiveStart(uint64_t bodyId);
+  ZMesh *readMeshArchiveNext(struct archive *arc);
+  void readMeshArchiveEnd(struct archive *arc);
 
   ZObject3dScan* readBodyDs(
       uint64_t bodyId, bool canonizing, ZObject3dScan *result);

--- a/neurolabi/gui/dvid/zdvidurl.cpp
+++ b/neurolabi/gui/dvid/zdvidurl.cpp
@@ -151,6 +151,20 @@ std::string ZDvidUrl::getMeshInfoUrl(uint64_t bodyId, int zoom)
   return getMeshUrl(bodyId, zoom) + "_info";
 }
 
+std::string ZDvidUrl::getMeshesTarsUrl()
+{
+  return getDataUrl(
+        ZDvidData::GetName(ZDvidData::ROLE_MESHES_TARS,
+                           ZDvidData::ROLE_BODY_LABEL,
+                           m_dvidTarget.getBodyLabelName()));
+}
+
+std::string ZDvidUrl::getMeshesTarsUrl(uint64_t bodyId)
+{
+  ZString dataUrl = getMeshesTarsUrl();
+  return GetFullUrl(GetKeyCommandUrl(dataUrl), GetBodyKey(bodyId));
+}
+
 std::string ZDvidUrl::getSkeletonUrl() const
 {
   return getSkeletonUrl(m_dvidTarget.getBodyLabelName());

--- a/neurolabi/gui/dvid/zdvidurl.h
+++ b/neurolabi/gui/dvid/zdvidurl.h
@@ -57,6 +57,9 @@ public:
 //  std::string getThumbnailUrl(const std::string &bodyLableName) const;
 //  std::string getThumbnailUrl(int bodyId) const;
 
+  std::string getMeshesTarsUrl();
+  std::string getMeshesTarsUrl(uint64_t bodyId);
+
   std::string getThumbnailUrl(const std::string &bodyLabelName) const;
   std::string
   getThumbnailUrl(uint64_t bodyId, const std::string &bodyLabelName) const;

--- a/neurolabi/gui/extlib.pri
+++ b/neurolabi/gui/extlib.pri
@@ -146,7 +146,7 @@ contains(DEFINES, _ENABLE_SURFRECON_) {
 exists($${CONDA_ENV}) {
   VTK_VER = 7.1
   INCLUDEPATH += $${CONDA_ENV}/include $${CONDA_ENV}/include/draco/src
-  LIBS += -L$${CONDA_ENV}/lib -lglbinding -lassimp -ldracoenc -ldracodec -ldraco
+  LIBS += -L$${CONDA_ENV}/lib -lglbinding -lassimp -ldracoenc -ldracodec -ldraco -larchive
   INCLUDEPATH += $${CONDA_ENV}/include/vtk-$${VTK_VER}
   LIBS += -lvtkFiltersGeometry-$${VTK_VER} -lvtkCommonCore-$${VTK_VER} -lvtksys-$${VTK_VER} -lvtkCommonDataModel-$${VTK_VER} -lvtkCommonMath-$${VTK_VER} -lvtkCommonMisc-$${VTK_VER} -lvtkCommonSystem-$${VTK_VER} -lvtkCommonTransforms-$${VTK_VER} -lvtkCommonExecutionModel-$${VTK_VER} -lvtkFiltersCore-$${VTK_VER} -lvtkFiltersSources-$${VTK_VER} -lvtkCommonComputationalGeometry-$${VTK_VER} -lvtkFiltersGeneral-$${VTK_VER}
 } else {

--- a/neurolabi/gui/flyem/zflyembody3ddoc.cpp
+++ b/neurolabi/gui/flyem/zflyembody3ddoc.cpp
@@ -1,6 +1,7 @@
 //#define _NEUTU_USE_REF_KEY_
 #include "zflyembody3ddoc.h"
 
+#include <archive.h>
 #include <QtConcurrentRun>
 #include <QMutexLocker>
 #include <QElapsedTimer>
@@ -104,6 +105,11 @@ void ZFlyEmBody3dDoc::enableBodySelectionSync(bool on)
   m_syncyingBodySelection = on;
 }
 
+void ZFlyEmBody3dDoc::enableGarbageLifetimeLimit(bool on)
+{
+  m_limitGarbageLifetime = on;
+}
+
 template<typename T>
 T* ZFlyEmBody3dDoc::recoverFromGarbage(const std::string &source)
 {
@@ -122,7 +128,7 @@ T* ZFlyEmBody3dDoc::recoverFromGarbage(const std::string &source)
         int dt = currentTime - t;
         if (dt < 0) {
           iter.value().setTimeStamp(0);
-        } else if (dt < OBJECT_ACTIVE_LIFE){
+        } else if (!m_limitGarbageLifetime || (dt < OBJECT_ACTIVE_LIFE)) {
           if (minDt < 0 || minDt > dt) {
             if (iter.key()->getSource() == source) {
               uint64_t bodyId =
@@ -184,6 +190,10 @@ void ZFlyEmBody3dDoc::setUnrecycable(const QSet<uint64_t> &bodySet)
 
 void ZFlyEmBody3dDoc::clearGarbage()
 {
+  if (!m_limitGarbageLifetime) {
+    return;
+  }
+
   QMutexLocker locker(&m_garbageMutex);
 
   ZOUT(LTRACE(), 5) << "Clear garbage objects ..." << m_garbageMap.size();
@@ -918,64 +928,81 @@ ZFlyEmBody3dDoc::BodyEvent ZFlyEmBody3dDoc::makeMultresBodyEvent(
 }
 
 void ZFlyEmBody3dDoc::addBodyMeshFunc(
-    uint64_t bodyId, const QColor &color, int resLevel)
+    uint64_t id, const QColor &color, int resLevel)
 {
-  bool loaded =
-      !(getObjectGroup().findSameClass(
-          ZStackObject::TYPE_MESH,
-          ZStackObjectSourceFactory::MakeFlyEmBodySource(bodyId)).
-        isEmpty());
-
   emit messageGenerated(ZWidgetMessage("Syncing 3D Body view ..."));
-  ZMesh *mesh = makeBodyMeshModel(bodyId, resLevel);
-  emit messageGenerated(ZWidgetMessage("3D Body view synced"));
+  std::map<uint64_t, ZMesh*> meshes;
+  makeBodyMeshModels(id, resLevel, meshes);
+  for (auto it : meshes) {
+    emit messageGenerated(ZWidgetMessage("3D Body view synced"));
 
-  if (mesh != NULL) {
-    resLevel = ZStackObjectSourceFactory::ExtractZoomFromFlyEmBodySource(
-          mesh->getSource());
-  }
+    uint64_t bodyId = it.first;
+    ZMesh *mesh = it.second;
 
-  if (resLevel > getMinResLevel()) {
-    QMutexLocker locker(&m_eventQueueMutex);
-    bool removing = false;
+    if (mesh != NULL) {
+      resLevel = ZStackObjectSourceFactory::ExtractZoomFromFlyEmBodySource(
+            mesh->getSource());
+    }
 
-    for (QQueue<BodyEvent>::iterator iter = m_eventQueue.begin();
-         iter != m_eventQueue.end(); ++iter) {
-      BodyEvent &event = *iter;
-      if (event.getBodyId() == bodyId) {
-        if (event.getAction() == BodyEvent::ACTION_REMOVE) {
-          removing = true;
-        } else {
-          removing = false;
+    if (resLevel > getMinResLevel()) {
+      QMutexLocker locker(&m_eventQueueMutex);
+      bool removing = false;
+
+      for (QQueue<BodyEvent>::iterator iter = m_eventQueue.begin();
+           iter != m_eventQueue.end(); ++iter) {
+        BodyEvent &event = *iter;
+        if (event.getBodyId() == bodyId) {
+          if (event.getAction() == BodyEvent::ACTION_REMOVE) {
+            removing = true;
+          } else {
+            removing = false;
+          }
         }
       }
+      if (!removing) {
+        BodyEvent bodyEvent = makeMultresBodyEvent(bodyId, resLevel - 1, color);
+        m_eventQueue.enqueue(bodyEvent);
+      }
     }
-    if (!removing) {
-      BodyEvent bodyEvent = makeMultresBodyEvent(bodyId, resLevel - 1, color);
-      m_eventQueue.enqueue(bodyEvent);
+
+    if (mesh != NULL) {
+  #ifdef _DEBUG_
+      std::cout << "Adding object: " << dynamic_cast<ZStackObject*>(mesh) << std::endl;
+      std::cout << "Color count: " << mesh->colors().size() << std::endl;
+      std::cout << "Vertex count: " << mesh->vertices().size() << std::endl;
+  #endif
+      mesh->setColor(color);
+      mesh->pushObjectColor();
+
+      updateBodyFunc(bodyId, mesh);
+
+      bool loaded =
+          !(getObjectGroup().findSameClass(
+              ZStackObject::TYPE_MESH,
+              ZStackObjectSourceFactory::MakeFlyEmBodySource(mesh->getLabel())).
+            isEmpty());
+
+      if (!loaded) {
+        addSynapse(bodyId);
+  //      addTodo(bodyId);
+        updateTodo(bodyId);
+
+        // TODO: As of December, 2017, the following is slow due to access of a desktop server,
+        // http://zhaot-ws1:9000.  This server should be replaced with a faster one.
+        // The problem is most noticeable for the functionality of taskbodyhistory.cpp.
+        loadSplitTask(bodyId);
+      }
+
+      // If the argument ID loads an archive, then makeBodyMeshModels() can create
+      // multiple meshes whose IDs need to be recorded, to make operations like
+      // selection work correctly.
+
+      m_bodySet.insert(mesh->getLabel());
     }
   }
 
-  if (mesh != NULL) {
-#ifdef _DEBUG_
-    std::cout << "Adding object: " << dynamic_cast<ZStackObject*>(mesh) << std::endl;
-    std::cout << "Color count: " << mesh->colors().size() << std::endl;
-    std::cout << "Vertex count: " << mesh->vertices().size() << std::endl;
-#endif
-    mesh->setColor(color);
-    mesh->pushObjectColor();
-
-    updateBodyFunc(bodyId, mesh);
-
-    if (!loaded) {
-      addSynapse(bodyId);
-//      addTodo(bodyId);
-      updateTodo(bodyId);
-      loadSplitTask(bodyId);
-    }
-  }
+  emit bodyMeshesAdded();
 }
-
 
 void ZFlyEmBody3dDoc::addBodyFunc(
     uint64_t bodyId, const QColor &color, int resLevel)
@@ -1770,58 +1797,137 @@ ZSwcTree* ZFlyEmBody3dDoc::makeBodyModel(
   return tree;
 }
 
-ZMesh* ZFlyEmBody3dDoc::makeBodyMeshModel(uint64_t bodyId, int zoom)
+namespace {
+  const uint64_t ENCODING_BASE = 100000000000;
+  const uint64_t ENCODING_TAR = 100;
+}
+
+uint64_t ZFlyEmBody3dDoc::encode(uint64_t rawId, unsigned int level, bool tar)
 {
-  ZMesh *mesh = recoverMeshFromGarbage(bodyId, zoom);
-#if 0 //todo
-  if (mesh == NULL) {
-    std::string source = ZStackObjectSourceFactory::MakeFlyEmBodySource(
-          bodyId, zoom, flyem::BODY_MESH);
-    mesh = dynamic_cast<ZMesh*>(
-          takeObjectFromCache(ZStackObject::TYPE_MESH, source));
-  }
-#endif
+  uint64_t tarEncoding = tar ? ENCODING_TAR : 0;
+  return (level + tarEncoding) * ENCODING_BASE + rawId;
+}
 
-  if (mesh == NULL) {
-    if (bodyId > 0) {
-      int t = m_objectTime.elapsed();
-      mesh = m_dvidReader.readMesh(bodyId, zoom);
+bool ZFlyEmBody3dDoc::encodesTar(uint64_t id) {
+  uint64_t encoded = id / ENCODING_BASE;
+  uint64_t encodedTar = encoded / ENCODING_TAR;
+  return (encodedTar != 0);
+}
 
-      if (mesh == NULL) {
-        bool loaded = false;
-        if (zoom > MAX_RES_LEVEL) {
-            loaded = !(getObjectGroup().findSameClass(
-                ZStackObject::TYPE_MESH,
-                ZStackObjectSourceFactory::MakeFlyEmBodySource(bodyId)).
-              isEmpty());
-        }
+unsigned int ZFlyEmBody3dDoc::encodedLevel(uint64_t id) {
+  uint64_t encoded = id / ENCODING_BASE;
+  uint64_t encodedLevel = encoded % ENCODING_TAR;
+  return encodedLevel;
+}
 
-        if (!loaded) { //Now make mesh
-          ZObject3dScan obj;
-          if (zoom == 0) {
-            m_dvidReader.readMultiscaleBody(bodyId, zoom, true, &obj);
-          } else if (zoom == MAX_RES_LEVEL){
-            m_dvidReader.readCoarseBody(bodyId, &obj);
-            obj.setDsIntv(getDvidInfo().getBlockSize() - 1);
-          }
-          mesh = ZMeshFactory::MakeMesh(obj);
+bool ZFlyEmBody3dDoc::getCachedMeshes(uint64_t bodyId, int zoom, std::map<uint64_t, ZMesh *> &result)
+{
+  if (encodesTar(bodyId)) {
+    auto it = m_tarIdToMeshIds.find(bodyId);
+    if (it != m_tarIdToMeshIds.end()) {
+      auto meshIds = it->second;
+      std::vector<ZMesh *> recoveredMeshes;
+
+      for (uint64_t meshId : meshIds) {
+        if (ZMesh *mesh = recoverMeshFromGarbage(meshId, 0)) {
+          recoveredMeshes.push_back(mesh);
         }
       }
 
-      if (mesh != NULL) {
-        mesh->prepareNormals();
-        mesh->setTimeStamp(t);
-        mesh->setSource(
-              ZStackObjectSourceFactory::MakeFlyEmBodySource(
-                bodyId, zoom, flyem::BODY_MESH));
-        mesh->setObjectClass(
-              ZStackObjectSourceFactory::MakeFlyEmBodySource(bodyId));
+      if (recoveredMeshes.size() == meshIds.size()) {
+        for (ZMesh *mesh : recoveredMeshes) {
+          result[mesh->getLabel()] = mesh;
+        }
+        return true;
+      }
+    }
+    return false;
+  } else {
+    ZMesh *mesh = recoverMeshFromGarbage(bodyId, zoom);
+  #if 0 //todo
+    if (mesh == NULL) {
+      std::string source = ZStackObjectSourceFactory::MakeFlyEmBodySource(
+            bodyId, zoom, flyem::BODY_MESH);
+      mesh = dynamic_cast<ZMesh*>(
+            takeObjectFromCache(ZStackObject::TYPE_MESH, source));
+    }
+  #endif
+    if (mesh) {
+      result[bodyId] = mesh;
+    }
+    return (mesh != nullptr);
+  }
+}
+
+ZMesh *ZFlyEmBody3dDoc::readMesh(uint64_t bodyId, int zoom)
+{
+  ZMesh *mesh = m_dvidReader.readMesh(bodyId, zoom);
+
+  if (mesh == NULL) {
+    bool loaded = false;
+    if (zoom > MAX_RES_LEVEL) {
+        loaded = !(getObjectGroup().findSameClass(
+            ZStackObject::TYPE_MESH,
+            ZStackObjectSourceFactory::MakeFlyEmBodySource(bodyId)).
+          isEmpty());
+    }
+
+    if (!loaded) { //Now make mesh
+      ZObject3dScan obj;
+      if (zoom == 0) {
+        m_dvidReader.readMultiscaleBody(bodyId, zoom, true, &obj);
+      } else if (zoom == MAX_RES_LEVEL){
+        m_dvidReader.readCoarseBody(bodyId, &obj);
+        obj.setDsIntv(getDvidInfo().getBlockSize() - 1);
+      }
+      mesh = ZMeshFactory::MakeMesh(obj);
+      if (mesh) {
         mesh->setLabel(bodyId);
       }
     }
   }
 
   return mesh;
+}
+
+namespace {
+  void finalizeMesh(ZMesh *mesh, int zoom, int t)
+  {
+    if (mesh) {
+      uint64_t id = mesh->getLabel();
+      mesh->prepareNormals();
+      mesh->setTimeStamp(t);
+      auto source = ZStackObjectSourceFactory::MakeFlyEmBodySource(id, zoom, flyem::BODY_MESH);
+      mesh->setSource(source);
+      auto objClass = ZStackObjectSourceFactory::MakeFlyEmBodySource(id);
+      mesh->setObjectClass(objClass);
+    }
+  }
+}
+
+void ZFlyEmBody3dDoc::makeBodyMeshModels(uint64_t id, int zoom, std::map<uint64_t, ZMesh*> &result)
+{
+  if ((id == 0) || getCachedMeshes(id, zoom, result)) {
+    return;
+  }
+
+  int t = m_objectTime.elapsed();
+
+  if (encodesTar(id)) {
+    m_tarIdToMeshIds[id].clear();
+    if (struct archive *arc = m_dvidReader.readMeshArchiveStart(id)) {
+      while (ZMesh *mesh = m_dvidReader.readMeshArchiveNext(arc)) {
+        finalizeMesh(mesh, 0, t);
+        result[mesh->getLabel()] = mesh;
+        m_tarIdToMeshIds[id].push_back(mesh->getLabel());
+      }
+      m_dvidReader.readMeshArchiveEnd(arc);
+    }
+  } else {
+    ZMesh *mesh = readMesh(id, zoom);
+    finalizeMesh(mesh, zoom, t);
+    result[id] = mesh;
+  }
 }
 
 const ZDvidInfo& ZFlyEmBody3dDoc::getDvidInfo() const

--- a/neurolabi/gui/flyem/zflyembodylistmodel.cpp
+++ b/neurolabi/gui/flyem/zflyembodylistmodel.cpp
@@ -73,6 +73,11 @@ void ZFlyEmBodyListModel::removeBody(uint64_t bodyId)
   }
 }
 
+void ZFlyEmBodyListModel::removeAllBodies()
+{
+  removeRows(0, rowCount(), QModelIndex());
+}
+
 QModelIndex ZFlyEmBodyListModel::getIndex(uint64_t bodyId) const
 {
   return index(getRow(bodyId));

--- a/neurolabi/gui/flyem/zflyembodylistmodel.h
+++ b/neurolabi/gui/flyem/zflyembodylistmodel.h
@@ -16,6 +16,7 @@ public:
   QModelIndex getIndex(uint64_t bodyId) const;
 
   void removeBody(uint64_t bodyId);
+  void removeAllBodies();
 
   void removeRowList(const QList<int> &rowList);
 

--- a/neurolabi/gui/flyem/zflyemproofmvc.cpp
+++ b/neurolabi/gui/flyem/zflyemproofmvc.cpp
@@ -732,7 +732,9 @@ Z3DWindow* ZFlyEmProofMvc::makeExternalMeshWindow(
 
   doc->showSynapse(m_meshWindow->isLayerVisible(Z3DWindow::LAYER_PUNCTA));
   setWindowSignalSlot(m_meshWindow);
-  m_meshWindow->getMeshFilter()->setColorMode("Mesh Color");
+  if (windowType != NeuTube3D::TYPE_NEU3) {
+      m_meshWindow->getMeshFilter()->setColorMode("Mesh Color");
+  }
   m_meshWindow->readSettings();
   m_meshWindow->syncAction();
 
@@ -4081,20 +4083,24 @@ void ZFlyEmProofMvc::addLocateBody(uint64_t bodyId)
   locateBody(bodyId, true);
 }
 
-void ZFlyEmProofMvc::selectBody(uint64_t bodyId)
+void ZFlyEmProofMvc::selectBody(uint64_t bodyId, bool postponeWindowUpdates)
 {
   getCompleteDocument()->recordBodySelection();
   getCompleteDocument()->selectBody(bodyId);
   getCompleteDocument()->processBodySelection();
-  updateBodySelection();
+  if (!postponeWindowUpdates) {
+    updateBodySelection();
+  }
 }
 
-void ZFlyEmProofMvc::deselectBody(uint64_t bodyId)
+void ZFlyEmProofMvc::deselectBody(uint64_t bodyId, bool postponeWindowUpdates)
 {
   getCompleteDocument()->recordBodySelection();
   getCompleteDocument()->deselectBody(bodyId);
   getCompleteDocument()->processBodySelection();
-  updateBodySelection();
+  if (!postponeWindowUpdates) {
+    updateBodySelection();
+  }
 }
 
 void ZFlyEmProofMvc::processViewChangeCustom(const ZStackViewParam &viewParam)

--- a/neurolabi/gui/flyem/zflyemproofmvc.h
+++ b/neurolabi/gui/flyem/zflyemproofmvc.h
@@ -210,8 +210,8 @@ public slots:
   bool locateBody(uint64_t bodyId);
 //  void locateBody(QList<uint64_t> bodyIdList); //obsolete function
   void addLocateBody(uint64_t bodyId);
-  void selectBody(uint64_t bodyId);
-  void deselectBody(uint64_t bodyId);
+  void selectBody(uint64_t bodyId, bool postponeWindowUpdates = false);
+  void deselectBody(uint64_t bodyId, bool postponeWindowUpdates = false);
   void selectBodyInRoi(bool appending = true);
   void selectBody(QList<uint64_t> bodyIdList);
   void notifyBodyMergeEdited();

--- a/neurolabi/gui/gui.pro
+++ b/neurolabi/gui/gui.pro
@@ -823,7 +823,8 @@ HEADERS += mainwindow.h \
     zcontrastprotocol.h \
     dialogs/zflyemmergeuploaddialog.h \
     zmeshfactory.h \
-    flyem/zflyemmeshfactory.h
+    flyem/zflyemmeshfactory.h \
+    protocols/taskbodyhistory.h
 
 FORMS += dialogs/settingdialog.ui \
     dialogs/frameinfodialog.ui \
@@ -1433,7 +1434,8 @@ SOURCES += main.cpp \
     zcontrastprotocol.cpp \
     dialogs/zflyemmergeuploaddialog.cpp \
     zmeshfactory.cpp \
-    flyem/zflyemmeshfactory.cpp
+    flyem/zflyemmeshfactory.cpp \
+    protocols/taskbodyhistory.cpp
 
 DISTFILES += \
     Resources/shader/wblended_final.frag \

--- a/neurolabi/gui/neu3window.h
+++ b/neurolabi/gui/neu3window.h
@@ -35,6 +35,9 @@ public:
   ZFlyEmBody3dDoc* getBodyDocument() const;
   ZFlyEmProofDoc* getDataDocument() const;
 
+  static void enableZoomToLoadedBody(bool enable = true);
+  static bool zoomToLoadedBodyEnabled();
+
 public slots:
   void showSynapse(bool on);
   void showTodo(bool on);
@@ -43,6 +46,12 @@ public slots:
    * \brief Remove a body from the current list.
    */
   void removeBody(uint64_t bodyId);
+
+  /*!
+   * \brief Remove all bodies from the current list, which can be more efficient
+   * than removing them one at a time.
+   */
+  void removeAllBodies();
 
   /*!
    * \brief Add a body to the body list.
@@ -84,6 +93,9 @@ private slots:
       QList<ZSwcTree*> selected,QList<ZSwcTree*>deselected);
   void processMeshChangedFrom3D(
       QList<ZMesh*> selected, QList<ZMesh*>deselected);
+
+  void syncBodyListModel();
+
   void test();
 
 private:
@@ -100,6 +112,8 @@ private:
   ZFlyEmProofMvc *m_dataContainer = NULL;
   QToolBar *m_toolBar = NULL;
   ZBodyListWidget *m_bodyListWidget = NULL;
+  bool m_doingBulkUpdate = false;
+  class DoingBulkUpdate;
 };
 
 #endif // NEU3WINDOW_H

--- a/neurolabi/gui/protocols/taskbodyhistory.cpp
+++ b/neurolabi/gui/protocols/taskbodyhistory.cpp
@@ -1,0 +1,105 @@
+#include "taskbodyhistory.h"
+
+#include "flyem/zflyembody3ddoc.h"
+#include "neu3window.h"
+#include "z3dmeshfilter.h"
+#include "z3dwindow.h"
+
+#include <iostream>
+#include <QSlider>
+
+namespace {
+
+  static const QString KEY_TASKTYPE = "task type";
+  static const QString VALUE_TASKTYPE = "body history";
+  static const QString KEY_BODYID = "body ID";
+  static const QString KEY_MAXLEVEL = "maximum level";
+
+  Z3DMeshFilter *getMeshFilter(ZStackDoc *doc)
+  {
+    if (Z3DWindow *window = doc->getParent3DWindow()) {
+      if (Z3DMeshFilter *filter =
+          dynamic_cast<Z3DMeshFilter*>(window->getMeshFilter())) {
+          return filter;
+       }
+    }
+    return nullptr;
+  }
+
+}
+
+TaskBodyHistory::TaskBodyHistory(QJsonObject json, ZFlyEmBody3dDoc* bodyDoc)
+{
+  m_bodyDoc = bodyDoc;
+
+  loadJson(json);
+
+  m_widget = new QSlider(Qt::Horizontal);
+  m_widget->setMaximum(m_maxLevel);
+  m_widget->setTickInterval(1);
+  m_widget->setTickPosition(QSlider::TicksBothSides);
+
+  connect(m_widget, SIGNAL(valueChanged(int)), this, SLOT(updateLevel(int)));
+
+  m_widget->setValue(m_maxLevel);
+
+  Neu3Window::enableZoomToLoadedBody(true);
+
+  if (Z3DMeshFilter *filter = getMeshFilter(m_bodyDoc)) {
+    filter->enablePreservingSourceColors(true);
+  }
+}
+
+QString TaskBodyHistory::tasktype()
+{
+  return VALUE_TASKTYPE;
+}
+
+QString TaskBodyHistory::actionString()
+{
+  return "Body history:";
+}
+
+QString TaskBodyHistory::targetString()
+{
+  return QString::number(m_bodyId);
+}
+
+QWidget *TaskBodyHistory::getTaskWidget()
+{
+  return m_widget;
+}
+
+void TaskBodyHistory::updateLevel(int level)
+{
+  Neu3Window::enableZoomToLoadedBody(false);
+  m_bodyDoc->enableGarbageLifetimeLimit(false);
+
+  QSet<uint64_t> visible({ ZFlyEmBody3dDoc::encode(m_bodyId, level) });
+
+  updateBodies(visible, QSet<uint64_t>());
+}
+
+QJsonObject TaskBodyHistory::addToJson(QJsonObject taskJson)
+{
+  return taskJson;
+}
+
+void TaskBodyHistory::onCompleted()
+{
+  Neu3Window::enableZoomToLoadedBody(true);
+
+  m_bodyDoc->enableGarbageLifetimeLimit(true);
+}
+
+bool TaskBodyHistory::loadSpecific(QJsonObject json)
+{
+  if (!json.contains(KEY_BODYID)) {
+    return false;
+  }
+
+  m_bodyId = json[KEY_BODYID].toDouble();
+  m_maxLevel = json[KEY_MAXLEVEL].toDouble();
+
+  return true;
+}

--- a/neurolabi/gui/protocols/taskbodyhistory.h
+++ b/neurolabi/gui/protocols/taskbodyhistory.h
@@ -1,0 +1,36 @@
+#ifndef TASKBODYHISTORY_H
+#define TASKBODYHISTORY_H
+
+#include "protocols/taskprotocoltask.h"
+#include <QObject>
+
+class ZFlyEmBody3dDoc;
+class QSlider;
+
+class TaskBodyHistory : public TaskProtocolTask
+{
+  Q_OBJECT
+public:
+  TaskBodyHistory(QJsonObject json, ZFlyEmBody3dDoc *bodyDoc);
+  QString tasktype() override;
+  QString actionString() override;
+  QString targetString() override;
+
+  virtual QWidget *getTaskWidget() override;
+
+private slots:
+  void updateLevel(int level);
+
+private:
+  ZFlyEmBody3dDoc *m_bodyDoc;
+  uint64_t m_bodyId;
+  int m_maxLevel;
+  QSlider *m_widget;
+
+  virtual bool loadSpecific(QJsonObject json) override;
+  virtual QJsonObject addToJson(QJsonObject json) override;
+  virtual void onCompleted() override;
+
+};
+
+#endif // TASKBODYHISTORY_H

--- a/neurolabi/gui/protocols/taskprotocoltask.cpp
+++ b/neurolabi/gui/protocols/taskprotocoltask.cpp
@@ -215,6 +215,14 @@ QString TaskProtocolTask::objectToString(QJsonObject json) {
     return jsonString;
 }
 
+void TaskProtocolTask::updateBodies(const QSet<uint64_t> &visible,
+                                    const QSet<uint64_t> &selected)
+{
+  m_visibleBodies = visible;
+  m_selectedBodies = selected;
+  emit(bodiesUpdated());
+}
+
 /*
  * produce the json that holds all the task data
  */

--- a/neurolabi/gui/protocols/taskprotocoltask.h
+++ b/neurolabi/gui/protocols/taskprotocoltask.h
@@ -37,6 +37,9 @@ public:
     virtual QString targetString() = 0;    
     virtual QWidget * getTaskWidget();
 
+signals:
+    void bodiesUpdated();
+
 protected:
     static const QString KEY_COMPLETED;
     static const QString KEY_TAGS;
@@ -49,6 +52,8 @@ protected:
     QSet<QString> m_tags;
 
     QString objectToString(QJsonObject json);
+
+    void updateBodies(const QSet<uint64_t> &visible, const QSet<uint64_t> &selected);
 
 private:
     bool loadStandard(QJsonObject json);

--- a/neurolabi/gui/widgets/taskprotocolwindow.h
+++ b/neurolabi/gui/widgets/taskprotocolwindow.h
@@ -32,7 +32,8 @@ public:
 signals:
     // I'm keeping the names Ting used in ZBodyListWidget (for now)
     void bodyAdded(uint64_t bodyId);
-    void bodyRemoved(uint64_t bodyId);
+    void allBodiesRemoved();
+
     void bodySelectionChanged(QSet<uint64_t> selectedSet);
     void prefetchBody(QSet<uint64_t> bodyIDs);
     void prefetchBody(uint64_t bodyID);
@@ -44,6 +45,7 @@ private slots:
     void onPrevButton();
     void onDoneButton();
     void onLoadTasksButton();    
+    void onBodiesUpdated();
     void onCompletedStateChanged(int state);
     void onReviewStateChanged(int state);
     void onShowCompletedStateChanged(int state);

--- a/neurolabi/gui/z3dmeshfilter.h
+++ b/neurolabi/gui/z3dmeshfilter.h
@@ -42,6 +42,8 @@ public:
 
   void setColorMode(const std::string &mode);
 
+  void enablePreservingSourceColors(bool on);
+
   bool hitObject(int x, int y);
   std::vector<bool> hitObject(const std::vector<std::pair<int, int> > &ptArray);
 
@@ -81,6 +83,7 @@ private:
   ZStringIntOptionParameter m_colorMode;
   ZVec4Parameter m_singleColorForAllMesh;
   std::map<QString, std::unique_ptr<ZVec4Parameter>, QStringNaturalCompare> m_sourceColorMapper;
+  bool m_preserveSourceColors;
 
   // mesh list used for rendering, it is a subset of m_origMeshList. Some mesh are
   // hidden because they are unchecked from the object model. This allows us to control

--- a/neurolabi/shell/neutu_conda_requirements.txt
+++ b/neurolabi/shell/neutu_conda_requirements.txt
@@ -15,3 +15,4 @@ assimp
 glbinding
 vtk=7.1*
 draco
+libarchive

--- a/recipe-neutu/meta.yaml
+++ b/recipe-neutu/meta.yaml
@@ -36,6 +36,7 @@ requirements:
     - assimp
     - glbinding
     - draco
+    - libarchive
 
   run:
     - python >=3.6
@@ -53,7 +54,8 @@ requirements:
     - assimp
     - glbinding
     - draco
-    
+    - libarchive
+   
 about:
   home: http://github.com/janelia-flyem/NeuTu
   license: GPL


### PR DESCRIPTION
…s, to support a Nue3 protocol that displays body (merge) history.

The body history of a higher-level body (e.g., one created by CELIS) describes how it was created by merging lower-level meshes (e.g., from super voxels).
A body history typically has two levels (level 0 being the super voxels, and level 1 being the CELIS agglomeration) but it could have more.
Body histories are stored in a new form of DVID key-value data instance.
There is a key-value pair for each level of a given body's history.
The key is the ID of the body, encoded to make each level distinct.
The associated value is a tar archive of the meshes for that level, compressed with Draco.
The name of each mesh file in the tar archive is the ID Neu3 will use for that mesh, and it has a further encoding to make all IDs unique (since the ID of a higher-level body is also the ID of one of its super voxels).

ZDvidData and ZDvidUrl have new code to construct the URL of the new data instance, which has the suffix "meshes_tars".
ZDvidReader has new code to read the new data instance, iteratively returning a ZMesh for each element of the archive.
It uses the Libarchive module to process the tar archive.
ZFlyEmBody3dDoc recognizes when the ID of a body to be added has the encoding of a key in the new data instance, and adds all the meshes from the associated tar archive.
To improve efficiency, it first tries to recover all the associated meshes from its "garbage", using a second cache to recover the IDs of the archived meshes associated with a given key ID.
To further improve efficiency, it provides new public API for disabling the code that limits the lifetime of meshes retained in the garbage, so the garbage will be usable as a cache for the duration of a user session.

The user interface for viewing the body history of a given body is implemented by TaskBodyHistory, a new class derived from TaskProtocolTask.
TaskBodyHistory needs to repeatedly change the visible bodies as the user moves back and forth through the body history levels with a slider, so TaskBodyTask now has a new updateBodies() function that emits a new bodiesUpdated() signal.
TaskProtocolWindow responds to that signal to update the body window.
That update process is now more efficient for the potentially-large numbers of bodies involved (from the lower levels of the hierarchy) in that it emits a single allBodiesRemoved() signal instead of a separate bodyRemoved(ID) signal for each body.
Nue3Window, which connects to this signal, thus can know to tell ZFlyEmProofMvc to avoid wasting time on repeated updates to the windows for each of the intermediate changes to the body list.
Neu3Window also uses this optimization when updating the ZFlyEmBodyListModel (displayed in the list widget at the left of main window) to display all the IDs of the meshes extracted from a tar archive, which is important for making each of those meshes individually selectable.

Z3dMeshFilter now uses a different algorithm for randomly assigning colors to meshes (i.e., sources), which varies the hue in a hue-saturation-lightness representation of the color, giving more distinguishable colors that the previous approach that worked with a red-green-blue representation.
Z3dMeshFilter also exposes public API to disable the resetting of these colors each time the list of meshes changes, so TaskBodyHistory can keep the colors consistent as the user moves back and forth through the body history.
