### PR TITLE
Add a Neu3 protocol for body “cleaving” (splitting at super voxel bou…

### DIFF
--- a/neurolabi/gui/dvid/zdvidreader.cpp
+++ b/neurolabi/gui/dvid/zdvidreader.cpp
@@ -642,6 +642,14 @@ ZMesh* ZDvidReader::readMesh(uint64_t bodyId, int zoom)
 
 struct archive *ZDvidReader::readMeshArchiveStart(uint64_t bodyId)
 {
+  size_t bytesTotal;
+  return readMeshArchiveStart(bodyId, bytesTotal);
+}
+
+struct archive *ZDvidReader::readMeshArchiveStart(uint64_t bodyId, size_t &bytesTotal)
+{
+  bytesTotal = 0;
+
   ZDvidUrl dvidUrl(getDvidTarget());
 
   m_bufferReader.read(dvidUrl.getMeshesTarsUrl(bodyId).c_str(), isVerbose());
@@ -659,11 +667,20 @@ struct archive *ZDvidReader::readMeshArchiveStart(uint64_t bodyId)
     return nullptr;
   }
 
+  bytesTotal = buffer.size();
   return arc;
 }
 
 ZMesh *ZDvidReader::readMeshArchiveNext(struct archive *arc)
 {
+  size_t bytesJustRead;
+  return readMeshArchiveNext(arc, bytesJustRead);
+}
+
+ZMesh *ZDvidReader::readMeshArchiveNext(struct archive *arc, size_t &bytesJustRead)
+{
+  bytesJustRead = 0;
+
   struct archive_entry *entry;
   if (archive_read_next_header(arc, &entry) != ARCHIVE_OK) {
     return nullptr;
@@ -685,6 +702,7 @@ ZMesh *ZDvidReader::readMeshArchiveNext(struct archive *arc)
     mesh->setLabel(std::stoull(bodyIdStr));
   }
 
+  bytesJustRead = size;
   return mesh;
 }
 

--- a/neurolabi/gui/dvid/zdvidreader.h
+++ b/neurolabi/gui/dvid/zdvidreader.h
@@ -137,7 +137,9 @@ public:
    * Draco-compressed meshes
    */
   struct archive *readMeshArchiveStart(uint64_t bodyId);
+  struct archive *readMeshArchiveStart(uint64_t bodyId, size_t &bytesTotal);
   ZMesh *readMeshArchiveNext(struct archive *arc);
+  ZMesh *readMeshArchiveNext(struct archive *arc, size_t &bytesJustRead);
   void readMeshArchiveEnd(struct archive *arc);
 
   ZObject3dScan* readBodyDs(

--- a/neurolabi/gui/flyem/zflyembody3ddoc.h
+++ b/neurolabi/gui/flyem/zflyembody3ddoc.h
@@ -335,6 +335,10 @@ signals:
   void bodyMeshLoaded();
   void bodyMeshesAdded();
 
+  void meshArchiveLoadingStarted();
+  void meshArchiveLoadingProgress(float fraction);
+  void meshArchiveLoadingEnded();
+
 private slots:
 //  void updateBody();
   void processEvent();

--- a/neurolabi/gui/gui.pro
+++ b/neurolabi/gui/gui.pro
@@ -824,7 +824,8 @@ HEADERS += mainwindow.h \
     dialogs/zflyemmergeuploaddialog.h \
     zmeshfactory.h \
     flyem/zflyemmeshfactory.h \
-    protocols/taskbodyhistory.h
+    protocols/taskbodyhistory.h \
+    protocols/taskbodycleave.h
 
 FORMS += dialogs/settingdialog.ui \
     dialogs/frameinfodialog.ui \
@@ -1435,7 +1436,8 @@ SOURCES += main.cpp \
     dialogs/zflyemmergeuploaddialog.cpp \
     zmeshfactory.cpp \
     flyem/zflyemmeshfactory.cpp \
-    protocols/taskbodyhistory.cpp
+    protocols/taskbodyhistory.cpp \
+    protocols/taskbodycleave.cpp
 
 DISTFILES += \
     Resources/shader/wblended_final.frag \

--- a/neurolabi/gui/neu3window.h
+++ b/neurolabi/gui/neu3window.h
@@ -10,6 +10,7 @@ class Neu3Window;
 class Z3DWindow;
 class Z3DCanvas;
 class ZFlyEmProofMvc;
+class QProgressDialog;
 class QToolBar;
 class ZFlyEmBody3dDoc;
 class ZFlyEmProofDoc;
@@ -96,6 +97,10 @@ private slots:
 
   void syncBodyListModel();
 
+  void meshArchiveLoadingStarted();
+  void meshArchiveLoadingProgress(float fraction);
+  void meshArchiveLoadingEnded();
+
   void test();
 
 private:
@@ -107,13 +112,14 @@ private:
 private:
   Ui::Neu3Window *ui;
 
-  Z3DCanvas *m_sharedContext = NULL;
-  Z3DWindow *m_3dwin = NULL;
-  ZFlyEmProofMvc *m_dataContainer = NULL;
-  QToolBar *m_toolBar = NULL;
-  ZBodyListWidget *m_bodyListWidget = NULL;
+  Z3DCanvas *m_sharedContext = nullptr;
+  Z3DWindow *m_3dwin = nullptr;
+  ZFlyEmProofMvc *m_dataContainer = nullptr;
+  QToolBar *m_toolBar = nullptr;
+  ZBodyListWidget *m_bodyListWidget = nullptr;
   bool m_doingBulkUpdate = false;
   class DoingBulkUpdate;
+  QProgressDialog *m_progressDialog = nullptr;
 };
 
 #endif // NEU3WINDOW_H

--- a/neurolabi/gui/protocols/taskbodycleave.cpp
+++ b/neurolabi/gui/protocols/taskbodycleave.cpp
@@ -1,0 +1,427 @@
+#include "taskbodycleave.h"
+
+#include "flyem/zflyembody3ddoc.h"
+#include "neu3window.h"
+#include "z3dmeshfilter.h"
+#include "z3dwindow.h"
+
+#include <iostream>
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QHBoxLayout>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QLabel>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QPixmap>
+#include <QPushButton>
+#include <QShortcut>
+#include <QSlider>
+#include <QUndoCommand>
+#include <QUrl>
+#include <QVBoxLayout>
+
+namespace {
+
+  static const QString KEY_TASKTYPE = "task type";
+  static const QString VALUE_TASKTYPE = "body cleave";
+  static const QString KEY_BODYID = "body ID";
+  static const QString KEY_MAXLEVEL = "maximum level";
+
+  static const std::vector<glm::vec4> INDEX_COLORS({
+    glm::vec4(255, 255, 255, 255) / 255.0f,
+    glm::vec4( 88, 121, 163, 255) / 255.0f,
+    glm::vec4(227, 146,  68, 255) / 255.0f,
+    glm::vec4(207,  96,  94, 255) / 255.0f,
+    glm::vec4(134, 181, 177, 255) / 255.0f,
+    glm::vec4(108, 158,  88, 255) / 255.0f,
+    glm::vec4(231, 200,  96, 255) / 255.0f,
+    glm::vec4(166, 125, 159, 255) / 255.0f,
+    glm::vec4(240, 162, 168, 255) / 255.0f,
+    glm::vec4(150, 118,  99, 255) / 255.0f
+  });
+
+  Z3DMeshFilter *getMeshFilter(ZStackDoc *doc)
+  {
+    if (Z3DWindow *window = doc->getParent3DWindow()) {
+      if (Z3DMeshFilter *filter =
+          dynamic_cast<Z3DMeshFilter*>(window->getMeshFilter())) {
+          return filter;
+       }
+    }
+    return nullptr;
+  }
+
+}
+
+//
+
+class TaskBodyCleave::SetCleaveIndicesCommand : public QUndoCommand
+{
+public:
+  SetCleaveIndicesCommand(TaskBodyCleave *task, std::map<uint64_t, std::size_t> meshIdToCleaveIndex) :
+    m_task(task),
+    m_meshIdToCleaveIndexBefore(task->m_meshIdToCleaveIndex),
+    m_meshIdToCleaveIndexAfter(meshIdToCleaveIndex)
+  {
+    setText("seeding for next cleave");
+  }
+
+  virtual void undo() override
+  {
+    m_task->m_meshIdToCleaveIndex = m_meshIdToCleaveIndexBefore;
+    m_task->updateColors();
+  }
+
+  virtual void redo() override
+  {
+    m_task->m_meshIdToCleaveIndex = m_meshIdToCleaveIndexAfter;
+    m_task->updateColors();
+  }
+
+private:
+  TaskBodyCleave *m_task;
+  std::map<uint64_t, std::size_t> m_meshIdToCleaveIndexBefore;
+  std::map<uint64_t, std::size_t> m_meshIdToCleaveIndexAfter;
+
+};
+
+class TaskBodyCleave::CleaveCommand : public QUndoCommand
+{
+public:
+  CleaveCommand(TaskBodyCleave *task, std::map<uint64_t, std::size_t> meshIdToCleaveIndex) :
+    m_task(task),
+    m_meshIdToLastCleaveIndexBefore(task->m_meshIdToLastCleaveIndex),
+    m_meshIdToCleaveIndexBefore(task->m_meshIdToCleaveIndex),
+    m_meshIdToLastCleaveIndexAfter(meshIdToCleaveIndex)
+  {
+    setText("cleave");
+  }
+
+  virtual void undo() override
+  {
+    m_task->m_meshIdToLastCleaveIndex = m_meshIdToLastCleaveIndexBefore;
+    m_task->m_meshIdToCleaveIndex = m_meshIdToCleaveIndexBefore;
+    m_task->updateColors();
+  }
+
+  virtual void redo() override
+  {
+    m_task->m_meshIdToLastCleaveIndex = m_meshIdToLastCleaveIndexAfter;
+    m_task->m_meshIdToCleaveIndex.clear();
+    m_task->updateColors();
+  }
+
+private:
+  TaskBodyCleave *m_task;
+  std::map<uint64_t, std::size_t> m_meshIdToLastCleaveIndexBefore;
+  std::map<uint64_t, std::size_t> m_meshIdToCleaveIndexBefore;
+  std::map<uint64_t, std::size_t> m_meshIdToLastCleaveIndexAfter;
+
+};
+
+//
+
+TaskBodyCleave::TaskBodyCleave(QJsonObject json, ZFlyEmBody3dDoc* bodyDoc)
+{
+  m_bodyDoc = bodyDoc;
+
+  loadJson(json);
+  buildTaskWidget();
+
+  m_networkManager = new QNetworkAccessManager(m_widget);
+  connect(m_networkManager, SIGNAL(finished(QNetworkReply*)),
+          this, SLOT(onNetworkReplyFinished(QNetworkReply*)));
+
+  Neu3Window::enableZoomToLoadedBody(true);
+
+  if (Z3DMeshFilter *filter = getMeshFilter(m_bodyDoc)) {
+    filter->enablePreservingSourceColors(true);
+  }
+}
+
+QString TaskBodyCleave::tasktype()
+{
+  return VALUE_TASKTYPE;
+}
+
+QString TaskBodyCleave::actionString()
+{
+  return "Body history:";
+}
+
+QString TaskBodyCleave::targetString()
+{
+  return QString::number(m_bodyId);
+}
+
+QWidget *TaskBodyCleave::getTaskWidget()
+{
+  return m_widget;
+}
+
+void TaskBodyCleave::updateLevel(int level)
+{
+  Neu3Window::enableZoomToLoadedBody(false);
+  m_bodyDoc->enableGarbageLifetimeLimit(false);
+
+  QSet<uint64_t> visible({ ZFlyEmBody3dDoc::encode(m_bodyId, level) });
+
+  updateBodies(visible, QSet<uint64_t>());
+}
+
+void TaskBodyCleave::onShowCleavingChanged(bool show)
+{
+  if (Z3DMeshFilter *filter = getMeshFilter(m_bodyDoc)) {
+    if (show) {
+      m_levelSlider->setValue(0);
+      filter->setColorMode("Indexed Color");
+    } else {
+      filter->setColorMode("Mesh Source");
+    }
+  }
+}
+
+void TaskBodyCleave::onChosenCleaveIndexChanged()
+{
+  if (QShortcut* shortcut = dynamic_cast<QShortcut*>(QObject::sender())) {
+    int i = shortcut->key().toString().toInt();
+    m_cleaveIndexComboBox->setCurrentIndex(i - 1);
+  }
+}
+
+void TaskBodyCleave::onAddToChosenCleaveBody()
+{
+  const TStackObjectSet &selectedMeshes = m_bodyDoc->getSelected(ZStackObject::TYPE_MESH);
+  std::map<uint64_t, size_t> meshIdToCleaveIndex(m_meshIdToCleaveIndex);
+
+  for (auto it = selectedMeshes.cbegin(); it != selectedMeshes.cend(); it++) {
+    ZMesh *mesh = static_cast<ZMesh*>(*it);
+    meshIdToCleaveIndex[mesh->getLabel()] = chosenCleaveIndex();
+  }
+
+  m_bodyDoc->pushUndoCommand(new SetCleaveIndicesCommand(this, meshIdToCleaveIndex));
+}
+
+void TaskBodyCleave::onRemoveFromChosenCleaveBody()
+{
+  const TStackObjectSet &selectedMeshes = m_bodyDoc->getSelected(ZStackObject::TYPE_MESH);
+  std::map<uint64_t, size_t> meshIdToCleaveIndex(m_meshIdToCleaveIndex);
+
+  for (auto it = selectedMeshes.cbegin(); it != selectedMeshes.cend(); it++) {
+    ZMesh *mesh = static_cast<ZMesh*>(*it);
+    meshIdToCleaveIndex.erase(mesh->getLabel());
+  }
+
+  m_bodyDoc->pushUndoCommand(new SetCleaveIndicesCommand(this, meshIdToCleaveIndex));
+}
+
+void TaskBodyCleave::onToggleInChosenCleaveBody()
+{
+  const TStackObjectSet &selectedMeshes = m_bodyDoc->getSelected(ZStackObject::TYPE_MESH);
+  std::map<uint64_t, size_t> meshIdToCleaveIndex(m_meshIdToCleaveIndex);
+
+  for (auto itSelected = selectedMeshes.cbegin(); itSelected != selectedMeshes.cend(); itSelected++) {
+    ZMesh *mesh = static_cast<ZMesh*>(*itSelected);
+    uint64_t id = mesh->getLabel();
+    auto itCleave = meshIdToCleaveIndex.find(id);
+    if ((itCleave == meshIdToCleaveIndex.end()) || (itCleave->second != chosenCleaveIndex())) {
+      meshIdToCleaveIndex[id] = chosenCleaveIndex();
+    } else {
+      meshIdToCleaveIndex.erase(id);
+    }
+  }
+
+  m_bodyDoc->pushUndoCommand(new SetCleaveIndicesCommand(this, meshIdToCleaveIndex));
+}
+
+void TaskBodyCleave::onCleave()
+{
+  QJsonObject requestJson;
+  requestJson["body-id"] = qint64(m_bodyId);
+
+  std::map<unsigned int, std::vector<uint64_t>> cleaveIndexToMeshIds;
+  for (auto it1 : m_meshIdToCleaveIndex) {
+    unsigned int cleaveIndex = it1.second;
+    auto it2 = cleaveIndexToMeshIds.find(cleaveIndex);
+    if (it2 == cleaveIndexToMeshIds.end()) {
+      cleaveIndexToMeshIds[cleaveIndex] = std::vector<uint64_t>();
+    }
+    uint64_t id = it1.first;
+    cleaveIndexToMeshIds[cleaveIndex].push_back(id);
+  }
+
+  QJsonObject requestJsonSeeds;
+
+  for (auto it : cleaveIndexToMeshIds) {
+    QJsonArray requestJsonSeedsForCleaveIndex;
+    for (uint64_t id : it.second) {
+      requestJsonSeedsForCleaveIndex.append(QJsonValue(qint64(id)));
+    }
+    int cleaveIndex = it.first;
+    requestJsonSeeds[QString::number(cleaveIndex)] = requestJsonSeedsForCleaveIndex;
+  }
+
+  requestJson["seeds"] = requestJsonSeeds;
+
+  // TODO: Switch to a better server host.
+  QUrl url("http://bergs-ws1.int.janelia.org:5555/compute-cleave");
+
+  QNetworkRequest request(url);
+  request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
+
+  QJsonDocument requestJsonDoc(requestJson);
+  QByteArray requestData(requestJsonDoc.toJson());
+
+  m_networkManager->post(request, requestData);
+}
+
+void TaskBodyCleave::onNetworkReplyFinished(QNetworkReply *reply)
+{
+  QNetworkReply::NetworkError error = reply->error();
+  std::cerr << "** received cleave reply **\n";
+  if (error == QNetworkReply::NoError) {
+    QByteArray replyBytes = reply->readAll();
+
+    QJsonDocument replyJsonDoc = QJsonDocument::fromJson(replyBytes);
+    if (replyJsonDoc.isObject()) {
+      QJsonObject replyJson = replyJsonDoc.object();
+      QJsonValue replyJsonAssnVal = replyJson["assignments"];
+      if (replyJsonAssnVal.isObject()) {
+        std::map<uint64_t, std::size_t> meshIdToCleaveIndex;
+
+        QJsonObject replyJsonAssn = replyJsonAssnVal.toObject();
+        for (QString key : replyJsonAssn.keys()) {
+          uint64_t cleaveIndex = key.toInt();
+          QJsonValue value = replyJsonAssn[key];
+          if (value.isArray()) {
+            for (QJsonValue idVal : value.toArray()) {
+              uint64_t id = idVal.toInt();
+              meshIdToCleaveIndex[id] = cleaveIndex;
+            }
+          }
+        }
+
+        m_bodyDoc->pushUndoCommand(new CleaveCommand(this, meshIdToCleaveIndex));
+      }
+    }
+
+  } else {
+    std::cerr << "** error \"" << reply->errorString().toStdString() << "\" **\n";
+  }
+
+  reply->deleteLater();
+}
+
+QJsonObject TaskBodyCleave::addToJson(QJsonObject taskJson)
+{
+  return taskJson;
+}
+
+void TaskBodyCleave::onCompleted()
+{
+  Neu3Window::enableZoomToLoadedBody(true);
+
+  m_bodyDoc->enableGarbageLifetimeLimit(true);
+}
+
+std::size_t TaskBodyCleave::chosenCleaveIndex() const
+{
+  return m_cleaveIndexComboBox->currentIndex() + 1;
+}
+
+
+void TaskBodyCleave::buildTaskWidget()
+{
+  m_widget = new QWidget();
+
+  QLabel *sliderLabel = new QLabel("History level", m_widget);
+  m_levelSlider = new QSlider(Qt::Horizontal, m_widget);
+  m_levelSlider->setMaximum(m_maxLevel);
+  m_levelSlider->setTickInterval(1);
+  m_levelSlider->setTickPosition(QSlider::TicksBothSides);
+
+  connect(m_levelSlider, SIGNAL(valueChanged(int)), this, SLOT(updateLevel(int)));
+
+  m_levelSlider->setValue(m_maxLevel);
+
+  QHBoxLayout *sliderLayout = new QHBoxLayout;
+  sliderLayout->addWidget(sliderLabel);
+  sliderLayout->addWidget(m_levelSlider);
+
+  QCheckBox *showCleavingCheckBox = new QCheckBox("Show cleaving", m_widget);
+  connect(showCleavingCheckBox, SIGNAL(clicked(bool)), this, SLOT(onShowCleavingChanged(bool)));
+
+  m_cleaveIndexComboBox = new QComboBox(m_widget);
+  QSize iconSizeDefault = m_cleaveIndexComboBox->iconSize();
+  QSize iconSize = iconSizeDefault * 0.8;
+  for (unsigned int i = 1; i < INDEX_COLORS.size(); i++) {
+    QPixmap pixmap(iconSize);
+    glm::vec4 color = 255.0f * INDEX_COLORS[i];
+    pixmap.fill(QColor(color.r, color.g, color.b, color.a));
+    QIcon icon(pixmap);
+    m_cleaveIndexComboBox->addItem(icon, "Cleaved body " + QString::number(i));
+  }
+
+  QPushButton *buttonAdd = new QPushButton("Add selection", m_widget);
+  connect(buttonAdd, SIGNAL(clicked(bool)), this, SLOT(onAddToChosenCleaveBody()));
+
+  QPushButton *buttonRemove = new QPushButton("Remove selection", m_widget);
+  connect(buttonRemove, SIGNAL(clicked(bool)), this, SLOT(onRemoveFromChosenCleaveBody()));
+
+  QPushButton *buttonCleave = new QPushButton("Cleave", m_widget);
+  connect(buttonCleave, SIGNAL(clicked(bool)), this, SLOT(onCleave()));
+
+  QHBoxLayout *familiesLayout = new QHBoxLayout;
+  familiesLayout->addWidget(showCleavingCheckBox);
+  familiesLayout->addWidget(m_cleaveIndexComboBox);
+  familiesLayout->addWidget(buttonAdd);
+  familiesLayout->addWidget(buttonRemove);
+
+  QVBoxLayout *layout = new QVBoxLayout;
+  layout->addLayout(sliderLayout);
+  layout->addLayout(familiesLayout);
+  layout->addWidget(buttonCleave);
+
+  m_widget->setLayout(layout);
+
+  // These explicit shortcuts seem to work better than shorcuts set on the buttons.
+
+  QShortcut *shortcutToggle = new QShortcut(Qt::Key_Space, m_widget);
+  connect(shortcutToggle, SIGNAL(activated()), this, SLOT(onToggleInChosenCleaveBody()));
+
+  for (int i = 0; i < m_cleaveIndexComboBox->count(); i++) {
+    QShortcut *shortcut = new QShortcut(QString::number(i + 1), m_widget);
+    connect(shortcut, SIGNAL(activated()), this, SLOT(onChosenCleaveIndexChanged()));
+  }
+}
+
+void TaskBodyCleave::updateColors()
+{
+  if (Z3DMeshFilter *filter = getMeshFilter(m_bodyDoc)) {
+    std::map<uint64_t, std::size_t> meshIdToCleaveIndex(m_meshIdToLastCleaveIndex);
+
+    for (auto it : m_meshIdToCleaveIndex) {
+      meshIdToCleaveIndex[it.first] = it.second;
+    }
+
+    filter->setColorIndexing(INDEX_COLORS, meshIdToCleaveIndex);
+  }
+}
+
+bool TaskBodyCleave::loadSpecific(QJsonObject json)
+{
+  if (!json.contains(KEY_BODYID)) {
+    return false;
+  }
+
+  m_bodyId = json[KEY_BODYID].toDouble();
+  m_maxLevel = json[KEY_MAXLEVEL].toDouble();
+
+  return true;
+}
+

--- a/neurolabi/gui/protocols/taskbodycleave.h
+++ b/neurolabi/gui/protocols/taskbodycleave.h
@@ -1,0 +1,68 @@
+#ifndef TASKBODYCLEAVE_H
+#define TASKBODYCLEAVE_H
+
+#include "protocols/taskprotocoltask.h"
+#include <QObject>
+
+#include <QVector>
+
+class ZFlyEmBody3dDoc;
+class QComboBox;
+class QNetworkAccessManager;
+class QNetworkReply;
+
+class QSlider;
+
+class TaskBodyCleave : public TaskProtocolTask
+{
+  Q_OBJECT
+public:
+  TaskBodyCleave(QJsonObject json, ZFlyEmBody3dDoc *bodyDoc);
+  QString tasktype() override;
+  QString actionString() override;
+  QString targetString() override;
+
+  virtual QWidget *getTaskWidget() override;
+
+private slots:
+  void updateLevel(int level);
+
+  void onShowCleavingChanged(bool show);
+  void onChosenCleaveIndexChanged();
+  void onAddToChosenCleaveBody();
+  void onRemoveFromChosenCleaveBody();
+  void onToggleInChosenCleaveBody();
+  void onCleave();
+
+  void onNetworkReplyFinished(QNetworkReply *reply);
+
+private:
+  QWidget *m_widget;
+  QSlider *m_levelSlider;
+  QComboBox *m_cleaveIndexComboBox;
+  ZFlyEmBody3dDoc *m_bodyDoc;
+  uint64_t m_bodyId;
+  int m_maxLevel;
+
+  // The cleave index assignments created by the last cleaving operation (initially empty).
+  std::map<uint64_t, std::size_t> m_meshIdToLastCleaveIndex;
+
+  // The cleave index assignments specified by the user, to be used for the next cleaving operation.
+  std::map<uint64_t, std::size_t> m_meshIdToCleaveIndex;
+
+  QNetworkAccessManager *m_networkManager;
+
+  class SetCleaveIndicesCommand;
+  class CleaveCommand;
+
+  std::size_t chosenCleaveIndex() const;
+
+  void buildTaskWidget();
+  void updateColors();
+
+  virtual bool loadSpecific(QJsonObject json) override;
+  virtual QJsonObject addToJson(QJsonObject json) override;
+  virtual void onCompleted() override;
+};
+
+#endif // TASKBODYCLEAVE_H

--- a/neurolabi/gui/widgets/taskprotocolwindow.cpp
+++ b/neurolabi/gui/widgets/taskprotocolwindow.cpp
@@ -15,6 +15,7 @@
 #include "flyem/zflyembody3ddoc.h"
 #include "protocols/bodyprefetchqueue.h"
 #include "protocols/taskbodyhistory.h"
+#include "protocols/taskbodycleave.h"
 #include "protocols/taskbodyreview.h"
 #include "protocols/tasksplitseeds.h"
 #include "protocols/tasktesttask.h"
@@ -406,8 +407,8 @@ void TaskProtocolWindow::startProtocol(QJsonObject json, bool save) {
 
     // load tasks from json into internal data structures; save to DVID if needed
     loadTasks(json);
-    if (save) {
-        saveState();
+    if (save && (m_currentTaskIndex >= 0)) {
+      saveState();
     }
 
     // load first task; enable UI and go
@@ -766,6 +767,9 @@ void TaskProtocolWindow::loadTasks(QJsonObject json) {
             m_taskList.append(task);
         } else if (taskType == "body history") {
           QSharedPointer<TaskProtocolTask> task(new TaskBodyHistory(taskJson.toObject(), m_body3dDoc));
+          m_taskList.append(task);
+        } else if (taskType == "body cleave") {
+          QSharedPointer<TaskProtocolTask> task(new TaskBodyCleave(taskJson.toObject(), m_body3dDoc));
           m_taskList.append(task);
         } else if (taskType == "split seeds") {
             // I'm not really fond of this task having a different constructor signature, but

--- a/neurolabi/gui/widgets/taskprotocolwindow.h
+++ b/neurolabi/gui/widgets/taskprotocolwindow.h
@@ -106,7 +106,7 @@ private:
     ZFlyEmBody3dDoc * m_body3dDoc;
     ZDvidWriter m_writer;
     ProtocolInstanceStatus m_protocolInstanceStatus;
-    int m_currentTaskIndex;
+    int m_currentTaskIndex = -1;
     QWidget * m_currentTaskWidget = NULL;
     bool m_nodeLocked;
     BodyPrefetchQueue * m_prefetchQueue;

--- a/neurolabi/gui/z3dmeshfilter.cpp
+++ b/neurolabi/gui/z3dmeshfilter.cpp
@@ -22,7 +22,7 @@ Z3DMeshFilter::Z3DMeshFilter(Z3DGlobalParameters& globalParas, QObject* parent)
   connect(&m_singleColorForAllMesh, &ZVec4Parameter::valueChanged, this, &Z3DMeshFilter::prepareColor);
 
   // Color Mode
-  m_colorMode.addOptions("Mesh Color", "Single Color", "Mesh Source");
+  m_colorMode.addOptions("Mesh Color", "Single Color", "Mesh Source", "Indexed Color");
   m_colorMode.select("Mesh Source");
 
   connect(&m_colorMode, &ZStringIntOptionParameter::valueChanged, this, &Z3DMeshFilter::prepareColor);
@@ -338,6 +338,20 @@ void Z3DMeshFilter::prepareColor()
     m_meshRenderer.setColorSource("CustomColor");
   } else if (m_colorMode.isSelected("Mesh Color")) {
     m_meshRenderer.setColorSource("MeshColor");
+  } else if (m_colorMode.isSelected("Indexed Color")) {
+    glm::vec4 defaultColor = m_indexedColors.size() > 1 ? m_indexedColors[0] : glm::vec4(1, 1, 1, 1);
+    for (size_t i = 0; i < m_meshList.size(); ++i) {
+      auto it = m_meshIDToColorIndex.find(m_meshList[i]->getLabel());
+      glm::vec4 color = defaultColor;
+      if (it != m_meshIDToColorIndex.end()) {
+        if (m_indexedColors.size() > it->second) {
+          color = m_indexedColors[it->second];
+        }
+      }
+      m_meshColors.push_back(color);
+    }
+    m_meshRenderer.setDataColors(&m_meshColors);
+    m_meshRenderer.setColorSource("CustomColor");
   }
 }
 
@@ -374,6 +388,14 @@ std::vector<bool> Z3DMeshFilter::hitObject(
   }
 
   return hitArray;
+}
+
+void Z3DMeshFilter::setColorIndexing(const std::vector<glm::vec4> &indexedColors,
+                                     const std::map<uint64_t, std::size_t> &meshIdToColorIndex)
+{
+  m_indexedColors = indexedColors;
+  m_meshIDToColorIndex = meshIdToColorIndex;
+  updateMeshVisibleState();
 }
 
 

--- a/neurolabi/gui/z3dmeshfilter.h
+++ b/neurolabi/gui/z3dmeshfilter.h
@@ -47,6 +47,9 @@ public:
   bool hitObject(int x, int y);
   std::vector<bool> hitObject(const std::vector<std::pair<int, int> > &ptArray);
 
+  // Meshes not mentioned in meshIdToColorIndex will get indexedColors[0].
+  void setColorIndexing(const std::vector<glm::vec4> &indexedColors,
+                        const std::map<uint64_t, std::size_t> &meshIdToColorIndex);
 signals:
 
   void meshSelected(ZMesh*, bool append);
@@ -105,6 +108,9 @@ private:
   bool m_dataIsInvalid;
 
   std::vector<ZMesh*> m_origMeshList;
+
+  std::vector<glm::vec4> m_indexedColors;
+  std::map<uint64_t, std::size_t> m_meshIDToColorIndex;
 };
 
 #endif // Z3DMESHFILTER_H


### PR DESCRIPTION
…ndaries).

The user interface for cleaving is implemented in the new TaskBodyCleave class, which derives from TaskProtocolTask.
This task has some body-history functionality similar to the TaskBodyHistory class.
The actual cleaving functionality is implemented by a server (whose code is not included here), which for the moment is running on a personal workstation.
The partitioning of super voxels that results from cleaving, and the recording of the seed super voxels that are the input for cleaving, are implemented with private commands derived from QUndoCommand.
Both operations involve assigning a common color to a set of meshes.
Z3DMeshFilter now supports this coloring with a new color mode, “Indexed Color”.
This new functionality required relatively little new code because it could reuse the m_meshColors array already in use for other color modes.

Note that this initial version of TaskBodyCleave does not actually write out the results of the cleaving operations.
This obviously necessary functionality will be added as future work.

ZDvidReader functions for reading a tar archive of meshes now optionally return the number of bytes for the archive and for the mesh just read.
These values are used by ZFlyEmBody3dDoc to emit signals describing (roughly) the progress of the reading from the archive.
Neu3Window connects to those signals to drive a QProgressDialog reporting the reading progress to the user.

This code also fixes two bugs in Neu3.

Neu3Window had a bug that caused the bodySelectionChanged(QSet<uint64_t> selectedSet) to be emitted twice after a click in the 3D display window.
It connected its bodySelected (and bodyDeselected) signal to its ZFlyEmBodyListView’s selectBodySliently (and deselectBodySliently) slots.
These versions pass true for the “silent” argument of  ZFlyEmBodyListView::setIndexSelection(), making it call ZFlyEmBodyListView::processSelectionChange() which emits bodySelectionChanged.
But ZFlyEmBodyListView::setIndexSelection() already triggers an eventual call to processSelectionChange() as a result of calling QItemSelectionModel::select(), because ZBodyListWidget's constructor connects QItemSelectionModel’s selectionChanged(QItemSelection,QItemSelection) signal to processSelectionChanged().
So Neu3Window should connect to the ZFlyEmBodyListView’s selectBody (and deselectBody) slots instead of the “silent” versions.

TaskProtocolWindow::startProtocol() also had a bug, in which saveState() was called even for the first protocol of a session.
Doing so sometimes caused a crash due to what seems indeterminate data.
So  TaskProtocolWindow now initializes m_currentTaskIndex to -1 so it can know to skip the call to saveState() in this situation.
