### PR TITLE
Add basic output of cleaving results.

### DIFF
--- a/neurolabi/gui/protocols/taskbodycleave.h
+++ b/neurolabi/gui/protocols/taskbodycleave.h
@@ -45,9 +45,10 @@ private:
   int m_maxLevel;
 
   // The cleave index assignments created by the last cleaving operation (initially empty).
-  std::map<uint64_t, std::size_t> m_meshIdToLastCleaveIndex;
+  std::map<uint64_t, std::size_t> m_meshIdToCleaveResultIndex;
 
-  // The cleave index assignments specified by the user, to be used for the next cleaving operation.
+  // The cleave index assignments specified by the user, to be used as seeds for the next
+  // cleaving operation.
   std::map<uint64_t, std::size_t> m_meshIdToCleaveIndex;
 
   QNetworkAccessManager *m_networkManager;


### PR DESCRIPTION
For now, the output is a DVID key-value instance, whose name is the name of the segmentation instance with the "_cleaved" suffix.
A key is the ID of an original body that was cleaved, and the value is JSON, an array of arrays, with each inner array being the IDs of the super voxels assigned to a particular cleaved body.
These super voxel IDs are sorted, which may improve inspection by a human, one of the primary uses of the output at this time.
 
This code also improves the functionality of multiple cleaving operations.
The seed assignments are no longer cleared after a cleaving operation, so they will persist for subsequent cleaving operations, which makes it easier to use subsequent cleaving operations to refine small pieces of earlier cleaving operations.