### PR TITLE
Improve TaskBodyCleave behavior on 'Next' and 'Prev' button presses.

### DIFF
--- a/neurolabi/gui/flyem/zflyembody3ddoc.cpp
+++ b/neurolabi/gui/flyem/zflyembody3ddoc.cpp
@@ -110,6 +110,11 @@ void ZFlyEmBody3dDoc::enableGarbageLifetimeLimit(bool on)
   m_limitGarbageLifetime = on;
 }
 
+bool ZFlyEmBody3dDoc::garbageLifetimeLimitEnabled() const
+{
+  return m_limitGarbageLifetime;
+}
+
 template<typename T>
 T* ZFlyEmBody3dDoc::recoverFromGarbage(const std::string &source)
 {

--- a/neurolabi/gui/flyem/zflyembody3ddoc.h
+++ b/neurolabi/gui/flyem/zflyembody3ddoc.h
@@ -220,6 +220,7 @@ public:
   void enableBodySelectionSync(bool on);
 
   void enableGarbageLifetimeLimit(bool on);
+  bool garbageLifetimeLimitEnabled() const;
 
   // The instances referred to by ZDvidUrl::getMeshesTarsUrl() represent data that
   // uses the body's identifier in multiple ways: for multiple meshes, at different

--- a/neurolabi/gui/protocols/taskbodycleave.h
+++ b/neurolabi/gui/protocols/taskbodycleave.h
@@ -7,9 +7,12 @@
 #include <QVector>
 
 class ZFlyEmBody3dDoc;
+class QCheckBox;
 class QComboBox;
 class QNetworkAccessManager;
 class QNetworkReply;
+class QPushButton;
+class QShortcut;
 
 class QSlider;
 
@@ -21,6 +24,10 @@ public:
   QString tasktype() override;
   QString actionString() override;
   QString targetString() override;
+
+  virtual void beforeNext() override;
+  virtual void beforePrev() override;
+  virtual void beforeDone() override;
 
   virtual QWidget *getTaskWidget() override;
 
@@ -37,12 +44,18 @@ private slots:
   void onNetworkReplyFinished(QNetworkReply *reply);
 
 private:
-  QWidget *m_widget;
-  QSlider *m_levelSlider;
-  QComboBox *m_cleaveIndexComboBox;
   ZFlyEmBody3dDoc *m_bodyDoc;
   uint64_t m_bodyId;
   int m_maxLevel;
+
+  QWidget *m_widget;
+  QSlider *m_levelSlider;
+  QCheckBox *m_showCleavingCheckBox;
+  QComboBox *m_cleaveIndexComboBox;
+  QPushButton *m_buttonAdd;
+  QPushButton *m_buttonRemove;
+  QPushButton *m_buttonCleave;
+  QShortcut *m_shortcutToggle;
 
   // The cleave index assignments created by the last cleaving operation (initially empty).
   std::map<uint64_t, std::size_t> m_meshIdToCleaveResultIndex;
@@ -60,6 +73,10 @@ private:
 
   void buildTaskWidget();
   void updateColors();
+
+  void applyPerTaskSettings();
+  void applyColorMode(bool showingCleaving);
+  void enableCleavingUI(bool showingCleaving);
 
   virtual bool loadSpecific(QJsonObject json) override;
   virtual QJsonObject addToJson(QJsonObject json) override;

--- a/neurolabi/gui/protocols/taskbodycleave.h
+++ b/neurolabi/gui/protocols/taskbodycleave.h
@@ -45,9 +45,10 @@ private:
   int m_maxLevel;
 
   // The cleave index assignments created by the last cleaving operation (initially empty).
-  std::map<uint64_t, std::size_t> m_meshIdToLastCleaveIndex;
+  std::map<uint64_t, std::size_t> m_meshIdToCleaveResultIndex;
 
-  // The cleave index assignments specified by the user, to be used for the next cleaving operation.
+  // The cleave index assignments specified by the user, to be used as seeds for the next
+  // cleaving operation.
   std::map<uint64_t, std::size_t> m_meshIdToCleaveIndex;
 
   QNetworkAccessManager *m_networkManager;

--- a/neurolabi/gui/protocols/taskprotocoltask.cpp
+++ b/neurolabi/gui/protocols/taskprotocoltask.cpp
@@ -69,7 +69,7 @@ void TaskProtocolTask::onCompleted() {
 
 /*
  * subclasses may optionally implement this method to
- * do something when the task about to be moved away from
+ * do something when a task is about to be moved away from
  * via "next" button
  */
 void TaskProtocolTask::beforeNext() {
@@ -78,12 +78,22 @@ void TaskProtocolTask::beforeNext() {
 
 /*
  * subclasses may optionally implement this method to
- * do something when the task about to be moved away from
+ * do something when a task is about to be moved away from
  * via "prev" button
  */
 void TaskProtocolTask::beforePrev() {
     // nothing
 }
+
+/*
+ * subclasses may optionally implement this method to
+ * do something in the task that is active when the "done" button
+ * is pressed
+ */
+void TaskProtocolTask::beforeDone() {
+  // nothing
+}
+
 
 /*
  * subclasses may optionally implement this method to

--- a/neurolabi/gui/protocols/taskprotocoltask.h
+++ b/neurolabi/gui/protocols/taskprotocoltask.h
@@ -22,6 +22,7 @@ public:
 
     virtual void beforeNext();
     virtual void beforePrev();
+    virtual void beforeDone();
 
     bool loadJson(QJsonObject json);
     QJsonObject toJson();

--- a/neurolabi/gui/widgets/taskprotocolwindow.cpp
+++ b/neurolabi/gui/widgets/taskprotocolwindow.cpp
@@ -276,6 +276,10 @@ void TaskProtocolWindow::onDoneButton() {
         return;
     }
 
+    if (m_currentTaskIndex >= 0) {
+      m_taskList[m_currentTaskIndex]->beforeDone();
+    }
+
     // new key is old key + either identifier or datetime stamp
     QString key;
     if (m_ID.size() > 0) {

--- a/neurolabi/gui/widgets/taskprotocolwindow.cpp
+++ b/neurolabi/gui/widgets/taskprotocolwindow.cpp
@@ -368,6 +368,7 @@ void TaskProtocolWindow::onShowCompletedStateChanged(int /*state*/) {
         updateBodyWindow();
         updateLabel();
     }
+    updateButtonsEnabled();
 }
 
 /*
@@ -604,8 +605,21 @@ void TaskProtocolWindow::updateCurrentTaskLabel() {
             ui->verticalLayout_3->addWidget(m_currentTaskWidget);
             // ui->horizontalLayout->addWidget(m_currentTaskWidget);
             m_currentTaskWidget->setVisible(true);
+            updateButtonsEnabled();
         }
     }
+}
+
+/*
+ * ensures that the "Next" and "Prev" buttons are enabled only when there are
+ * next or previous tasks to go to
+ */
+void TaskProtocolWindow::updateButtonsEnabled()
+{
+  bool nextPrevEnabled = ((m_taskList.size() > 1) &&
+                          ((getNextUncompleted() != -1) || ui->showCompletedCheckBox->isChecked()));
+  ui->nextButton->setEnabled(nextPrevEnabled);
+  ui->prevButton->setEnabled(nextPrevEnabled);
 }
 
 /*

--- a/neurolabi/gui/widgets/taskprotocolwindow.h
+++ b/neurolabi/gui/widgets/taskprotocolwindow.h
@@ -126,6 +126,7 @@ private:
     void startProtocol(QJsonObject json, bool save);
     void updateLabel();
     void updateCurrentTaskLabel();
+    void updateButtonsEnabled();
     int getFirstUncompleted();
     void showInfo(QString title, QString message);
     void gotoCurrentTask();

--- a/neurolabi/gui/z3dmeshfilter.cpp
+++ b/neurolabi/gui/z3dmeshfilter.cpp
@@ -73,6 +73,10 @@ void Z3DMeshFilter::enablePreservingSourceColors(bool on)
   m_preserveSourceColors = on;
 }
 
+bool Z3DMeshFilter::preservingSourceColorsEnabled() const
+{
+  return m_preserveSourceColors;
+}
 
 void Z3DMeshFilter::setData(const std::vector<ZMesh*>& meshList)
 {

--- a/neurolabi/gui/z3dmeshfilter.h
+++ b/neurolabi/gui/z3dmeshfilter.h
@@ -43,6 +43,7 @@ public:
   void setColorMode(const std::string &mode);
 
   void enablePreservingSourceColors(bool on);
+  bool preservingSourceColorsEnabled() const;
 
   bool hitObject(int x, int y);
   std::vector<bool> hitObject(const std::vector<std::pair<int, int> > &ptArray);


### PR DESCRIPTION
A user can load multiple TaskBodyCleave instances from one JSON file, and the user interface for each instance can trigger changes that need to be restored when “Next” and “Prev” buttons move away from the instance and then back to it.
For example, the “Show cleaving” check box changes the Z3DMeshFilter color mode between “Mesh Source” and “Indexed Color”, and each TaskBodyCleave has its own setting for this check box.
TaskBodyCleave now has code to manage these changes.

This code also clears the ZFlyEmBody3dDoc undo stack on “Next” / “Prev”, because SetCleaveIndicesCommand and CleaveCommand instances on the stack contain information that does not make sense outside the original TaskBodyCleave.

Some related code also now disables the parts of the user interface related to cleaving (e.g., the “Cleave” button) when the “Show cleaving” check box is not checked.

There also are some settings that need to be in effect for all the TaskBodyCleave instances loaded from one JSON file, and need to be reset when the “Done” button disables all those instances. 
For example, ZFlyEmBody3dDoc::garbageLifetimeLimitEnabled() should be false for all TaskBodyCleave instances (so the garbage functions as a cache for the meshes), but the normal value is false.
TaskBodyCleave now also has code to save these “overall” settings when the first TaskBodyCleave is created, and restore them when the “Done” button is pressed.
To support code called when “Done” is pressed, TaskProtocolTask has a new virtual function, beforeDone(), and TaskProtocolWindow calls it at the appropriate time.
ZFlyEmBody3dDoc and Z3DMeshFilter also have new accessor functions for some of the settings that need to be saved.