### PR TITLE
Disable 'Next'/'Prev' buttons when there is nothing to go to.

### DIFF
--- a/neurolabi/gui/widgets/taskprotocolwindow.cpp
+++ b/neurolabi/gui/widgets/taskprotocolwindow.cpp
@@ -368,6 +368,7 @@ void TaskProtocolWindow::onShowCompletedStateChanged(int /*state*/) {
         updateBodyWindow();
         updateLabel();
     }
+    updateButtonsEnabled();
 }
 
 /*
@@ -604,8 +605,21 @@ void TaskProtocolWindow::updateCurrentTaskLabel() {
             ui->verticalLayout_3->addWidget(m_currentTaskWidget);
             // ui->horizontalLayout->addWidget(m_currentTaskWidget);
             m_currentTaskWidget->setVisible(true);
+            updateButtonsEnabled();
         }
     }
+}
+
+/*
+ * ensures that the "Next" and "Prev" buttons are enabled only when there are
+ * next or previous tasks to go to
+ */
+void TaskProtocolWindow::updateButtonsEnabled()
+{
+  bool nextPrevEnabled = ((m_taskList.size() > 1) &&
+                          ((getNextUncompleted() != -1) || ui->showCompletedCheckBox->isChecked()));
+  ui->nextButton->setEnabled(nextPrevEnabled);
+  ui->prevButton->setEnabled(nextPrevEnabled);
 }
 
 /*

--- a/neurolabi/gui/widgets/taskprotocolwindow.h
+++ b/neurolabi/gui/widgets/taskprotocolwindow.h
@@ -126,6 +126,7 @@ private:
     void startProtocol(QJsonObject json, bool save);
     void updateLabel();
     void updateCurrentTaskLabel();
+    void updateButtonsEnabled();
     int getFirstUncompleted();
     void showInfo(QString title, QString message);
     void gotoCurrentTask();


### PR DESCRIPTION
Fixes the bug described in Trello as "Bug: protocol can get stuck in a difficult-to-end state."

Should be merged into "develop" after the merging of "neu3-body-cleave-next-prev".