### PR TITLE
Allow disabling of loading split tasks to improve performance.

### DIFF
--- a/neurolabi/gui/flyem/zflyembody3ddoc.cpp
+++ b/neurolabi/gui/flyem/zflyembody3ddoc.cpp
@@ -1311,6 +1311,10 @@ void ZFlyEmBody3dDoc::updateSegmentation()
 
 void ZFlyEmBody3dDoc::loadSplitTask(uint64_t bodyId)
 {
+  if (!m_splitTaskLoadingEnabled) {
+    return;
+  }
+
   QList<ZStackObject*> seedList =
       ZFlyEmMisc::LoadSplitTask(getDvidTarget(), bodyId);
 
@@ -1324,6 +1328,16 @@ void ZFlyEmBody3dDoc::loadSplitTask(uint64_t bodyId)
     //A dangerous way to share objects. Need object clone or shared pointer.
 //    ZStackDocAccessor::AddObject(getDataDocument(), seedList);
   }
+}
+
+void ZFlyEmBody3dDoc::enableSplitTaskLoading(bool enable)
+{
+  m_splitTaskLoadingEnabled = enable;
+}
+
+bool ZFlyEmBody3dDoc::splitTaskLoadingEnabled() const
+{
+  return m_splitTaskLoadingEnabled;
 }
 
 ZFlyEmToDoItem ZFlyEmBody3dDoc::makeTodoItem(

--- a/neurolabi/gui/flyem/zflyembody3ddoc.h
+++ b/neurolabi/gui/flyem/zflyembody3ddoc.h
@@ -168,7 +168,10 @@ public:
   ZFlyEmToDoItem makeTodoItem(
       int x, int y, int z, bool checked, uint64_t bodyId);
   ZFlyEmToDoItem readTodoItem(int x, int y, int z) const;
+
   void loadSplitTask(uint64_t bodyId);
+  void enableSplitTaskLoading(bool enable);
+  bool splitTaskLoadingEnabled() const;
 
   void addEvent(BodyEvent::EAction action, uint64_t bodyId,
                 BodyEvent::TUpdateFlag flag = 0, QMutex *mutex = NULL);
@@ -419,6 +422,7 @@ private:
   std::map<uint64_t, std::vector<uint64_t>> m_tarIdToMeshIds;
 
   bool m_limitGarbageLifetime = true;
+  bool m_splitTaskLoadingEnabled = true;
 
   const static int OBJECT_GARBAGE_LIFE;
   const static int OBJECT_ACTIVE_LIFE;

--- a/neurolabi/gui/protocols/taskbodycleave.cpp
+++ b/neurolabi/gui/protocols/taskbodycleave.cpp
@@ -87,6 +87,7 @@ namespace {
   static bool applyOverallSettingsNeeded = true;
   static bool zoomToLoadedBodyEnabled;
   static bool garbageLifetimeLimitEnabled;
+  static bool splitTaskLoadingEnabled;
   static bool preservingSourceColorEnabled;
 
   void applyOverallSettings(ZFlyEmBody3dDoc* bodyDoc)
@@ -98,6 +99,9 @@ namespace {
 
       garbageLifetimeLimitEnabled = bodyDoc->garbageLifetimeLimitEnabled();
       bodyDoc->enableGarbageLifetimeLimit(false);
+
+      splitTaskLoadingEnabled = bodyDoc->splitTaskLoadingEnabled();
+      bodyDoc->enableSplitTaskLoading(false);
 
       if (Z3DMeshFilter *filter = getMeshFilter(bodyDoc)) {
         preservingSourceColorEnabled = filter->preservingSourceColorsEnabled();
@@ -114,6 +118,8 @@ namespace {
       Neu3Window::enableZoomToLoadedBody(zoomToLoadedBodyEnabled);
 
       bodyDoc->enableGarbageLifetimeLimit(garbageLifetimeLimitEnabled);
+
+      bodyDoc->enableSplitTaskLoading(splitTaskLoadingEnabled);
 
       if (Z3DMeshFilter *filter = getMeshFilter(bodyDoc)) {
         filter->enablePreservingSourceColors(preservingSourceColorEnabled);


### PR DESCRIPTION
This change builds on the "neu3-body-cleave-ui-v2" branch but really should be merged into the "develop" branch.