### PR TITLE
Neu3 body cleave data server v2

### DIFF
--- a/neurolabi/gui/dvid/zdvidurl.cpp
+++ b/neurolabi/gui/dvid/zdvidurl.cpp
@@ -168,7 +168,8 @@ std::string ZDvidUrl::getMeshesTarsUrl()
 std::string ZDvidUrl::getMeshesTarsUrl(uint64_t bodyId)
 {
   ZString dataUrl = getMeshesTarsUrl();
-  return GetFullUrl(GetKeyCommandUrl(dataUrl), GetBodyKey(bodyId));
+  ZString key = GetBodyKey(bodyId) + ".tar";
+  return GetFullUrl(GetKeyCommandUrl(dataUrl), key);
 }
 
 std::string ZDvidUrl::getSkeletonUrl() const

--- a/neurolabi/gui/flyem/zflyembody3ddoc.cpp
+++ b/neurolabi/gui/flyem/zflyembody3ddoc.cpp
@@ -1311,6 +1311,10 @@ void ZFlyEmBody3dDoc::updateSegmentation()
 
 void ZFlyEmBody3dDoc::loadSplitTask(uint64_t bodyId)
 {
+  if (!m_splitTaskLoadingEnabled) {
+    return;
+  }
+
   QList<ZStackObject*> seedList =
       ZFlyEmMisc::LoadSplitTask(getDvidTarget(), bodyId);
 
@@ -1324,6 +1328,16 @@ void ZFlyEmBody3dDoc::loadSplitTask(uint64_t bodyId)
     //A dangerous way to share objects. Need object clone or shared pointer.
 //    ZStackDocAccessor::AddObject(getDataDocument(), seedList);
   }
+}
+
+void ZFlyEmBody3dDoc::enableSplitTaskLoading(bool enable)
+{
+  m_splitTaskLoadingEnabled = enable;
+}
+
+bool ZFlyEmBody3dDoc::splitTaskLoadingEnabled() const
+{
+  return m_splitTaskLoadingEnabled;
 }
 
 ZFlyEmToDoItem ZFlyEmBody3dDoc::makeTodoItem(

--- a/neurolabi/gui/flyem/zflyembody3ddoc.cpp
+++ b/neurolabi/gui/flyem/zflyembody3ddoc.cpp
@@ -1171,10 +1171,20 @@ void ZFlyEmBody3dDoc::showSynapse(bool on)
   addSynapse(on);
 }
 
+bool ZFlyEmBody3dDoc::showingSynapse() const
+{
+  return m_showingSynapse;
+}
+
 void ZFlyEmBody3dDoc::showTodo(bool on)
 {
   m_showingTodo = on;
   addTodo(on);
+}
+
+bool ZFlyEmBody3dDoc::showingTodo() const
+{
+  return m_showingTodo;
 }
 
 bool ZFlyEmBody3dDoc::synapseLoaded(uint64_t bodyId) const

--- a/neurolabi/gui/flyem/zflyembody3ddoc.h
+++ b/neurolabi/gui/flyem/zflyembody3ddoc.h
@@ -254,8 +254,10 @@ public:
 
 public slots:
   void showSynapse(bool on);// { m_showingSynapse = on; }
+  bool showingSynapse() const;
   void addSynapse(bool on);
   void showTodo(bool on);
+  bool showingTodo() const;
   void addTodo(bool on);
   void updateTodo(uint64_t bodyId);
   void setUnrecycable(const QSet<uint64_t> &bodySet);

--- a/neurolabi/gui/flyem/zflyembody3ddoc.h
+++ b/neurolabi/gui/flyem/zflyembody3ddoc.h
@@ -168,7 +168,10 @@ public:
   ZFlyEmToDoItem makeTodoItem(
       int x, int y, int z, bool checked, uint64_t bodyId);
   ZFlyEmToDoItem readTodoItem(int x, int y, int z) const;
+
   void loadSplitTask(uint64_t bodyId);
+  void enableSplitTaskLoading(bool enable);
+  bool splitTaskLoadingEnabled() const;
 
   void addEvent(BodyEvent::EAction action, uint64_t bodyId,
                 BodyEvent::TUpdateFlag flag = 0, QMutex *mutex = NULL);
@@ -419,6 +422,7 @@ private:
   std::map<uint64_t, std::vector<uint64_t>> m_tarIdToMeshIds;
 
   bool m_limitGarbageLifetime = true;
+  bool m_splitTaskLoadingEnabled = true;
 
   const static int OBJECT_GARBAGE_LIFE;
   const static int OBJECT_ACTIVE_LIFE;

--- a/neurolabi/gui/protocols/taskbodycleave.cpp
+++ b/neurolabi/gui/protocols/taskbodycleave.cpp
@@ -87,6 +87,7 @@ namespace {
   static bool applyOverallSettingsNeeded = true;
   static bool zoomToLoadedBodyEnabled;
   static bool garbageLifetimeLimitEnabled;
+  static bool splitTaskLoadingEnabled;
   static bool preservingSourceColorEnabled;
 
   void applyOverallSettings(ZFlyEmBody3dDoc* bodyDoc)
@@ -98,6 +99,9 @@ namespace {
 
       garbageLifetimeLimitEnabled = bodyDoc->garbageLifetimeLimitEnabled();
       bodyDoc->enableGarbageLifetimeLimit(false);
+
+      splitTaskLoadingEnabled = bodyDoc->splitTaskLoadingEnabled();
+      bodyDoc->enableSplitTaskLoading(false);
 
       if (Z3DMeshFilter *filter = getMeshFilter(bodyDoc)) {
         preservingSourceColorEnabled = filter->preservingSourceColorsEnabled();
@@ -114,6 +118,8 @@ namespace {
       Neu3Window::enableZoomToLoadedBody(zoomToLoadedBodyEnabled);
 
       bodyDoc->enableGarbageLifetimeLimit(garbageLifetimeLimitEnabled);
+
+      bodyDoc->enableSplitTaskLoading(splitTaskLoadingEnabled);
 
       if (Z3DMeshFilter *filter = getMeshFilter(bodyDoc)) {
         filter->enablePreservingSourceColors(preservingSourceColorEnabled);

--- a/neurolabi/gui/protocols/taskbodycleave.cpp
+++ b/neurolabi/gui/protocols/taskbodycleave.cpp
@@ -88,6 +88,8 @@ namespace {
   static bool zoomToLoadedBodyEnabled;
   static bool garbageLifetimeLimitEnabled;
   static bool splitTaskLoadingEnabled;
+  static bool showingTodo;
+  static bool showingSynapse;
   static bool preservingSourceColorEnabled;
 
   void applyOverallSettings(ZFlyEmBody3dDoc* bodyDoc)
@@ -102,6 +104,12 @@ namespace {
 
       splitTaskLoadingEnabled = bodyDoc->splitTaskLoadingEnabled();
       bodyDoc->enableSplitTaskLoading(false);
+
+      showingTodo = bodyDoc->showingTodo();
+      bodyDoc->showTodo(false);
+
+      showingSynapse = bodyDoc->showingSynapse();
+      bodyDoc->showSynapse(false);
 
       if (Z3DMeshFilter *filter = getMeshFilter(bodyDoc)) {
         preservingSourceColorEnabled = filter->preservingSourceColorsEnabled();
@@ -118,8 +126,9 @@ namespace {
       Neu3Window::enableZoomToLoadedBody(zoomToLoadedBodyEnabled);
 
       bodyDoc->enableGarbageLifetimeLimit(garbageLifetimeLimitEnabled);
-
       bodyDoc->enableSplitTaskLoading(splitTaskLoadingEnabled);
+      bodyDoc->showTodo(showingTodo);
+      bodyDoc->showSynapse(showingSynapse);
 
       if (Z3DMeshFilter *filter = getMeshFilter(bodyDoc)) {
         filter->enablePreservingSourceColors(preservingSourceColorEnabled);
@@ -651,9 +660,7 @@ void TaskBodyCleave::cleave()
 
   requestJson["seeds"] = requestJsonSeeds;
 
-  // TODO: Switch to a better server host.
-  QUrl url("http://bergs-ws1.int.janelia.org:5555/compute-cleave");
-
+  QUrl url("http://bergs-ws1.int.janelia.org:5556/compute-cleave");
   QNetworkRequest request(url);
   request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
 

--- a/neurolabi/gui/zstackobject.h
+++ b/neurolabi/gui/zstackobject.h
@@ -243,7 +243,7 @@ public:
     return m_label;
   }
 */
-  inline std::string getSource() const { return m_source; }
+  inline const std::string &getSource() const { return m_source; }
   inline void setSource(const std::string &source) { m_source = source; }
 
   /*!
@@ -256,13 +256,13 @@ public:
   static bool fromSameSource(const ZStackObject *obj1, const ZStackObject *obj2);
 
 
-  inline std::string getObjectId() const { return m_objectId; }
+  inline const std::string &getObjectId() const { return m_objectId; }
   inline void setObjectId(const std::string &id) { m_objectId = id; }
 
   bool hasSameId(const ZStackObject *obj) const;
   static bool hasSameId(const ZStackObject *obj1, const ZStackObject *obj2);
 
-  inline std::string getObjectClass() const { return m_objectClass; }
+  inline const std::string &getObjectClass() const { return m_objectClass; }
   inline void setObjectClass(const std::string &id) { m_objectClass = id; }
 
 


### PR DESCRIPTION
The format of keys in the "meshes_tars" DVID instance has changed slightly, with the addition of ".tar" the encoded body ID.

The port for the test version of the cleaving server has changed, to 5556.

TaskBodyCleave now disables the showing of todo indications and synapses, to avoid the overhead of checking DVID for that information repeatedly for every super voxel.

ZStackObject now returns const references to some std::string data members, to avoid the overhead for copying the strings.