### PR TITLE
setup_neutu_env: Pin Qt5 and Python3 in the development environment

### DIFF
--- a/neurolabi/shell/setup_neutu_env
+++ b/neurolabi/shell/setup_neutu_env
@@ -10,6 +10,7 @@ fi
 CONDA_DIR=$1
 ENV_NAME=${2:-neutu-env}
 condarc=$CONDA_DIR/.condarc
+ENV_DIR=$CONDA_DIR/envs/$ENV_NAME
 
 if [ ! -f $condarc ]
 then
@@ -18,12 +19,20 @@ fi
 
 source $CONDA_DIR/bin/activate root
 conda create -n $ENV_NAME python=3.6 -y
+
+# Create a special file to tell the conda solver that upgrading/downgrading Qt and Python is forbidden.
+# https://conda.io/docs/user-guide/tasks/manage-pkgs.html?highlight=pinned#preventing-packages-from-updating-pinning
+/bin/cat <<EOF > ${ENV_DIR}/conda-meta/pinned
+python=3*
+qt=5*
+EOF
+
 source $CONDA_DIR/bin/activate $ENV_NAME
 conda install --file neutu_conda_requirements.txt -y
 if [ `uname` == 'Linux' ]; then
   conda install pango=1.40* -y
 fi
-./fixqtdebug Qt5 $CONDA_DIR/envs/$ENV_NAME/lib
+./fixqtdebug Qt5 ${ENV_DIR}/lib
 
 
 


### PR DESCRIPTION
Pin Qt and Python to prevent accidental upgrading during environment setup.

FWIW, The downgrade issue (Qt5->Qt4) that @hubbardp encountered was caused by to the extra install step for `pango` (on linux only), on [this line](https://github.com/janelia-flyem/NeuTu/blob/develop/neurolabi/shell/setup_neutu_env#L24).

For reference, I'm using this feature of conda to prevent accidental upgrading:
https://conda.io/docs/user-guide/tasks/manage-pkgs.html?highlight=pinned#preventing-packages-from-updating-pinning

I think this is a stop-gap solution.  I think a better solution would be to create a separate meta-package for all NeuTu dependencies, and have the setup script use that, rather than multiple `conda install` steps, which essentially must duplicate NeuTu's dependency list.
