### PR TITLE
Fix draco decoding of normals, colors, etc. Also, de-duplicate mesh after decoding

### DIFF
--- a/neurolabi/gui/zmeshio.cpp
+++ b/neurolabi/gui/zmeshio.cpp
@@ -132,9 +132,9 @@ void getDracoVertices(const PointCloud& pc, std::vector<glm::vec3>& vertices)
   const PointAttribute *const att = pc.GetNamedAttribute(GeometryAttribute::POSITION);
   if (att == nullptr || att->size() == 0)
     throw ZIOException("no vertices found in draco file");
-  vertices.resize(att->size());
-  for (AttributeValueIndex i(0); i < att->size(); ++i) {
-    if (!att->ConvertValue<float, 3>(i, &vertices[i.value()][0])) {
+  vertices.resize(pc.num_points());
+  for (PointIndex i(0); i < pc.num_points(); ++i) {
+    if (!att->ConvertValue<float, 3>(att->mapped_index(i), &vertices[i.value()][0])) {
       vertices.clear();
       throw ZIOException("can not decode draco vertices");
     }
@@ -148,9 +148,10 @@ void getDracoNormals(const PointCloud& pc, std::vector<glm::vec3>& normals)
     return; // no normal
   }
   if (att->num_components() == 3) {
-    normals.resize(att->size());
-    for (AttributeValueIndex i(0); i < att->size(); ++i) {
-      if (!att->ConvertValue<float, 3>(i, &normals[i.value()][0])) {
+    PointIndex num_points = pc.num_points();
+    normals.resize(num_points.value());
+    for (PointIndex i(0); i < num_points; ++i) {
+      if (!att->ConvertValue<float, 3>(att->mapped_index(i), &normals[i.value()][0])) {
         normals.clear();
         throw ZIOException("can not decode draco normals");
       }
@@ -167,9 +168,9 @@ void getDracoColors(const PointCloud& pc, std::vector<glm::vec4>& colors)
     return; // no color
   }
   if (att->num_components() == 1) {
-    colors.resize(att->size());
-    for (AttributeValueIndex i(0); i < att->size(); ++i) {
-      if (!att->ConvertValue<float, 1>(i, &colors[i.value()][0])) {
+    colors.resize(pc.num_points());
+    for (PointIndex i(0); i < pc.num_points(); ++i) {
+      if (!att->ConvertValue<float, 1>(att->mapped_index(i), &colors[i.value()][0])) {
         colors.clear();
         throw ZIOException("can not decode draco 1 component colors");
       }
@@ -178,9 +179,9 @@ void getDracoColors(const PointCloud& pc, std::vector<glm::vec4>& colors)
       c.a = 1.f;
     }
   } else if (att->num_components() == 2) {
-    colors.resize(att->size());
-    for (AttributeValueIndex i(0); i < att->size(); ++i) {
-      if (!att->ConvertValue<float, 2>(i, &colors[i.value()][0])) {
+    colors.resize(pc.num_points());
+    for (PointIndex i(0); i < pc.num_points(); ++i) {
+      if (!att->ConvertValue<float, 2>(att->mapped_index(i), &colors[i.value()][0])) {
         colors.clear();
         throw ZIOException("can not decode draco 2 component colors");
       }
@@ -189,9 +190,9 @@ void getDracoColors(const PointCloud& pc, std::vector<glm::vec4>& colors)
       c.a = 1.f;
     }
   } else if (att->num_components() == 3) {
-    colors.resize(att->size());
-    for (AttributeValueIndex i(0); i < att->size(); ++i) {
-      if (!att->ConvertValue<float, 3>(i, &colors[i.value()][0])) {
+    colors.resize(pc.num_points());
+    for (PointIndex i(0); i < pc.num_points(); ++i) {
+      if (!att->ConvertValue<float, 3>(att->mapped_index(i), &colors[i.value()][0])) {
         colors.clear();
         throw ZIOException("can not decode draco 3 component colors");
       }
@@ -200,9 +201,9 @@ void getDracoColors(const PointCloud& pc, std::vector<glm::vec4>& colors)
       c.a = 1.f;
     }
   } else if (att->num_components() == 4) {
-    colors.resize(att->size());
-    for (AttributeValueIndex i(0); i < att->size(); ++i) {
-      if (!att->ConvertValue<float, 4>(i, &colors[i.value()][0])) {
+    colors.resize(pc.num_points());
+    for (PointIndex i(0); i < pc.num_points(); ++i) {
+      if (!att->ConvertValue<float, 4>(att->mapped_index(i), &colors[i.value()][0])) {
         colors.clear();
         throw ZIOException("can not decode draco 4 component colors");
       }
@@ -222,25 +223,25 @@ void getDracoTextureCoordinates(const PointCloud& pc,
     return; // no textureCoordinates2D
   }
   if (att->num_components() == 1) {
-    textureCoordinates1D.resize(att->size());
-    for (AttributeValueIndex i(0); i < att->size(); ++i) {
-      if (!att->ConvertValue<float, 1>(i, &textureCoordinates1D[i.value()])) {
+    textureCoordinates1D.resize(pc.num_points());
+    for (PointIndex i(0); i < pc.num_points(); ++i) {
+      if (!att->ConvertValue<float, 1>(att->mapped_index(i), &textureCoordinates1D[i.value()])) {
         textureCoordinates1D.clear();
         throw ZIOException("can not decode draco textureCoordinates1D");
       }
     }
   } else if (att->num_components() == 2) {
-    textureCoordinates2D.resize(att->size());
-    for (AttributeValueIndex i(0); i < att->size(); ++i) {
-      if (!att->ConvertValue<float, 2>(i, &textureCoordinates2D[i.value()][0])) {
+    textureCoordinates2D.resize(pc.num_points());
+    for (PointIndex i(0); i < pc.num_points(); ++i) {
+      if (!att->ConvertValue<float, 2>(att->mapped_index(i), &textureCoordinates2D[i.value()][0])) {
         textureCoordinates2D.clear();
         throw ZIOException("can not decode draco textureCoordinates2D");
       }
     }
   } else if (att->num_components() == 3) {
-    for (AttributeValueIndex i(0); i < att->size(); ++i) {
-      textureCoordinates3D.resize(att->size());
-      if (!att->ConvertValue<float, 3>(i, &textureCoordinates3D[i.value()][0])) {
+    for (PointIndex i(0); i < pc.num_points(); ++i) {
+      textureCoordinates3D.resize(pc.num_points());
+      if (!att->ConvertValue<float, 3>(att->mapped_index(i), &textureCoordinates3D[i.value()][0])) {
         textureCoordinates3D.clear();
         throw ZIOException("can not decode draco textureCoordinates3D");
       }
@@ -257,7 +258,7 @@ void getDracoFaces(const Mesh& msh, std::vector<GLuint>& faces)
   for (FaceIndex i(0); i < msh.num_faces(); ++i) {
     for (int j = 0; j < 3; ++j) {
       const PointIndex vert_index = msh.face(i)[j];
-      faces[i.value()*3+j] = pos_att_->mapped_index(vert_index).value();
+      faces[i.value()*3+j] = vert_index.value();
     }
   }
 }

--- a/neurolabi/gui/zmeshio.cpp
+++ b/neurolabi/gui/zmeshio.cpp
@@ -641,6 +641,14 @@ void ZMeshIO::readDracoMeshFromMemory(
     std::unique_ptr<draco::Mesh> in_mesh = std::move(statusor).value();
     if (in_mesh) {
       msh = in_mesh.get();
+
+      // Draco encoding may cause duplication of vertices data.
+      // De-duplicate after decoding.
+      // Note: These functions are not defined unless you build with a special preprocessor definition:
+      //       Make sure NeuTu is built with -D DRACO_ATTRIBUTE_DEDUPLICATION_SUPPORTED=1
+      msh->DeduplicateAttributeValues();
+      msh->DeduplicatePointIds();
+
       pc = std::move(in_mesh);
     }
   } else if (geom_type == draco::POINT_CLOUD) {


### PR DESCRIPTION
[Disclaimer: I haven't compiled these changes myself, but I implemented something similar in my own python bindings for draco.  Apologies for any typos, etc.]

This PR has two commits.

First commit ("Use point indicies for decoding attributes..."):
------------

From looking at the NeuTu source code, I think NeuTu isn't decoding draco point attributes correctly (such as normals).

This is a patch to fix that.  NeuTu was using "mapped" (i.e. internal) indices for positions, normals, colors, etc., and decoding face indexes to their 'mapped' values as well.  But that leads to two problems:

1. Internally, draco might de-duplicate vertex attributes, so if point 1 and point 2 happen to have the same normal value (or position value), the number of unique "mapped" values will not match the number of points.  For instance, the number of 'mapped' positions might not match the number of mapped normals.

2. Even if there was no duplication of any vertices and normals (so, the 'mapped' lists happen to have the correct length), the mapping from point index -> stored position is not necessarily the same as the mapping of the point index -> stored normal.  This would cause your decoded normals to be associated with the wrong vertices.  (I believe we noticed this when I tried to provide pre-computed normals in some meshes last week.)

Second commit ("De-duplicate mesh points...")
--------------

On a somewhat-related note: From my testing, draco may sometimes duplicate vertices and normals during the encoding process, at least for certain (perhaps unusual) cases.  In the interest of saving RAM, I think it's best to run de-duplication on the mesh after it's decoded.  (Note: As mentioned in the comments, you must build with `DRACO_ATTRIBUTE_DEDUPLICATION_SUPPORTED`.)

