### PR TITLE
Neu3 body cleave error handling

### DIFF
--- a/neurolabi/gui/flyem/zflyembody3ddoc.cpp
+++ b/neurolabi/gui/flyem/zflyembody3ddoc.cpp
@@ -2428,12 +2428,15 @@ void ZFlyEmBody3dDoc::makeBodyMeshModels(uint64_t id, int zoom, std::map<uint64_
 
       emit meshArchiveLoadingEnded();
     } else {
-      emit messageGenerated(
-            ZWidgetMessage(
-              "Mesh Loading Failed", "Failed to read mesh archive from dvid",
-              neutube::MSG_WARNING, ZWidgetMessage::TARGET_DIALOG));
+      QString title = "Mesh Loading Failed";
+      uint64_t idUnencoded = unencode(id);
+      QString text = "DVID mesh archive does not contain ID " +
+          QString::number(idUnencoded) + " (encoded as " + QString::number(id) + ")";
+      ZWidgetMessage msg(title, text, neutube::MSG_ERROR, ZWidgetMessage::TARGET_DIALOG);
+      emit messageGenerated(msg);
       emit meshArchiveLoadingEnded();
     }
+
   } else {
     ZStackObject *obj = takeObjectFromBuffer(
           ZStackObject::TYPE_MESH,

--- a/neurolabi/gui/protocols/taskbodycleave.cpp
+++ b/neurolabi/gui/protocols/taskbodycleave.cpp
@@ -447,7 +447,7 @@ void TaskBodyCleave::onNetworkReplyFinished(QNetworkReply *reply)
           QJsonValue value = replyJsonAssn[key];
           if (value.isArray()) {
             for (QJsonValue idVal : value.toArray()) {
-              uint64_t id = idVal.toInt();
+              uint64_t id = idVal.toDouble();
               meshIdToCleaveIndex[id] = cleaveIndex;
             }
           }

--- a/neurolabi/gui/protocols/taskbodycleave.h
+++ b/neurolabi/gui/protocols/taskbodycleave.h
@@ -3,10 +3,11 @@
 
 #include "protocols/taskprotocoltask.h"
 #include <QObject>
-
 #include <QVector>
+#include <set>
 
 class ZFlyEmBody3dDoc;
+class ZMesh;
 class QAction;
 class QCheckBox;
 class QComboBox;
@@ -82,11 +83,17 @@ private:
   void buildTaskWidget();
   void updateColors();
 
+  void selectBodies(const std::set<uint64_t>& toSelect);
+
   void applyPerTaskSettings();
   void applyColorMode(bool showingCleaving);
   void enableCleavingUI(bool showingCleaving);
 
   void cleave();
+
+  bool showCleaveReplyWarnings(const QJsonObject& reply);
+  bool showCleaveReplyDataErrors(std::map<uint64_t, std::size_t> meshIdToCleaveIndex);
+  void displayWarning(const QString& title, const QString& text);
 
   virtual bool loadSpecific(QJsonObject json) override;
   virtual QJsonObject addToJson(QJsonObject json) override;


### PR DESCRIPTION
Also fixes a bug in how the Neu3 cleaving tool interprets the super voxel IDs sent from the cleaving server.  The 64-bit IDs were inadvertently being converted to 32 bits temporarily, causing certain super voxels to appear to be omitted. 