### PR TITLE
Neu3 bug empty selection box

### DIFF
--- a/neurolabi/gui/z3dmeshfilter.cpp
+++ b/neurolabi/gui/z3dmeshfilter.cpp
@@ -119,6 +119,7 @@ bool Z3DMeshFilter::showingSourceColors() const
 
 void Z3DMeshFilter::setData(const std::vector<ZMesh*>& meshList)
 {
+  m_meshBoundboxMapper.clear();
   m_origMeshList = meshList;
   //LOG(INFO) << className() << " read " << m_origMeshList.size() << " meshes.";
   getVisibleData();
@@ -130,8 +131,8 @@ void Z3DMeshFilter::setData(const std::vector<ZMesh*>& meshList)
 
 void Z3DMeshFilter::setData(const QList<ZMesh*>& meshList)
 {
-  m_origMeshList.clear();
   m_meshBoundboxMapper.clear();
+  m_origMeshList.clear();
   for (auto mesh : meshList)
     m_origMeshList.push_back(mesh);
   //LOG(INFO) << className() << " read " << m_origMeshList.size() << " meshes.";

--- a/neurolabi/gui/z3dmeshfilter.cpp
+++ b/neurolabi/gui/z3dmeshfilter.cpp
@@ -131,6 +131,7 @@ void Z3DMeshFilter::setData(const std::vector<ZMesh*>& meshList)
 void Z3DMeshFilter::setData(const QList<ZMesh*>& meshList)
 {
   m_origMeshList.clear();
+  m_meshBoundboxMapper.clear();
   for (auto mesh : meshList)
     m_origMeshList.push_back(mesh);
   //LOG(INFO) << className() << " read " << m_origMeshList.size() << " meshes.";


### PR DESCRIPTION
Make sure that if the address of a mesh is reused, then the cached bounding box is not reused but instead is recomputed.