### PR TITLE
Prevent problems due to interacting with a protocol task while it is loading

### DIFF
--- a/neurolabi/gui/flyem/zflyembody3ddoc.cpp
+++ b/neurolabi/gui/flyem/zflyembody3ddoc.cpp
@@ -1402,7 +1402,7 @@ void ZFlyEmBody3dDoc::addBodyMeshFunc(
     // can be used by code that needs to know the IDs of the loaded meshes (instead of
     // the ID of the archive).
 
-    emit bodyMeshesAdded();
+    emit bodyMeshesAdded(meshes.size());
   }
 }
 
@@ -1846,7 +1846,7 @@ void ZFlyEmBody3dDoc::updateBodyFunc(uint64_t bodyId, ZStackObject *bodyObject)
   QString threadId = QString("updateBody(%1)").arg(bodyId);
   if (!m_futureMap.isAlive(threadId)) {
 
-    // The findSameClass() function has performance that iis quadratic in the number of meshes,
+    // The findSameClass() function has performance that is quadratic in the number of meshes,
     // and is unnecessary for meshes from a tar archive.
 
     if (!fromTar(bodyId)) {

--- a/neurolabi/gui/flyem/zflyembody3ddoc.cpp
+++ b/neurolabi/gui/flyem/zflyembody3ddoc.cpp
@@ -1914,6 +1914,7 @@ void ZFlyEmBody3dDoc::recycleObject(ZStackObject *obj)
 {
   if (removeObject(obj, false)) {
     dumpGarbage(obj, true);
+    emit bodyRecycled(obj->getLabel());
   }
 }
 

--- a/neurolabi/gui/flyem/zflyembody3ddoc.h
+++ b/neurolabi/gui/flyem/zflyembody3ddoc.h
@@ -379,6 +379,7 @@ public slots:
 
 signals:
   void bodyRemoved(uint64_t bodyId);
+  void bodyRecycled(uint64_t bodyId);
   void interactionStateChanged();
 
   //Signals for triggering external body control

--- a/neurolabi/gui/flyem/zflyembody3ddoc.h
+++ b/neurolabi/gui/flyem/zflyembody3ddoc.h
@@ -473,7 +473,7 @@ private:
 signals:
   void todoVisibleChanged();
   void bodyMeshLoaded();
-  void bodyMeshesAdded();
+  void bodyMeshesAdded(int);
 
   void meshArchiveLoadingStarted();
   void meshArchiveLoadingProgress(float fraction);

--- a/neurolabi/gui/protocols/taskbodycleave.cpp
+++ b/neurolabi/gui/protocols/taskbodycleave.cpp
@@ -357,6 +357,17 @@ void TaskBodyCleave::onShowCleavingChanged(int state)
 
 void TaskBodyCleave::onToggleShowCleaving()
 {
+  // For some reason, Qt will call this slot even when the source of the signal is disabled.
+  // The source is a QAction on m_menu, and TaskProtocolWindow disables it and m_widget while
+  // waiting for meshes from the previous task to e deleted and meshes for the next task to be
+  // loaded.  In this case, going ahead and loading more meshes for cleaving can cause problems
+  // due to way meshes are deleted and loaded asynchronously.  Since this disabling does not
+  // prevent this slot from being called, we must explicitly abort this slot when there is
+  // disabling.
+
+  if (!m_menu->isEnabled() || !m_widget->isEnabled()) {
+    return;
+  }
   m_showCleavingCheckBox->setChecked(!m_showCleavingCheckBox->isChecked());
 }
 

--- a/neurolabi/gui/protocols/taskprotocoltask.cpp
+++ b/neurolabi/gui/protocols/taskprotocoltask.cpp
@@ -41,11 +41,11 @@ bool TaskProtocolTask::completed() const
     return m_completed;
 }
 
-QSet<uint64_t> TaskProtocolTask::visibleBodies() {
+const QSet<uint64_t> & TaskProtocolTask::visibleBodies() {
     return m_visibleBodies;
 }
 
-QSet<uint64_t> TaskProtocolTask::selectedBodies() {
+const QSet<uint64_t> & TaskProtocolTask::selectedBodies() {
     return m_selectedBodies;
 }
 

--- a/neurolabi/gui/protocols/taskprotocoltask.h
+++ b/neurolabi/gui/protocols/taskprotocoltask.h
@@ -19,8 +19,8 @@ public:
 
     bool completed() const;
     void setCompleted(bool completed);
-    QSet<uint64_t> visibleBodies();
-    QSet<uint64_t> selectedBodies();
+    const QSet<uint64_t> & visibleBodies();
+    const QSet<uint64_t> & selectedBodies();
 
     virtual void beforeNext();
     virtual void beforePrev();

--- a/neurolabi/gui/widgets/taskprotocolwindow.cpp
+++ b/neurolabi/gui/widgets/taskprotocolwindow.cpp
@@ -23,6 +23,7 @@
 #include "protocols/tasksplitseeds.h"
 #include "protocols/tasktesttask.h"
 #include "z3dwindow.h"
+#include "zstackdocproxy.h"
 #include "zwidgetmessage.h"
 
 #include "taskprotocolwindow.h"
@@ -76,6 +77,8 @@ TaskProtocolWindow::TaskProtocolWindow(ZFlyEmProofDoc *doc, ZFlyEmBody3dDoc *bod
             this, &TaskProtocolWindow::onBodyMeshesAdded, Qt::QueuedConnection);
     connect(m_body3dDoc, &ZFlyEmBody3dDoc::bodyMeshLoaded,
             this, &TaskProtocolWindow::onBodyMeshLoaded, Qt::QueuedConnection);
+    connect(m_body3dDoc, &ZFlyEmBody3dDoc::bodyRecycled,
+            this, &TaskProtocolWindow::onBodyRecycled);
 }
 
 // constants
@@ -711,38 +714,66 @@ void TaskProtocolWindow::updateBodyWindow() {
 
 void TaskProtocolWindow::disableButtonsWhileUpdating()
 {
-    m_bodyMeshLoadedExpected = 0;
-    m_bodyMeshLoadedReceived = 0;
-
     // If the user triggers several calls to updateBodyWindow() in rapid succession, by
     // quickly moving between tasks and using controls from the task widget that also change
     // the loaded bodies, then the bodies loaded by one call may not be fully cleared by the
     // next call, due to the way bodies are added and removed asynchronously in a background
     // thread.  The problem seems worst for meshes loaded from a tar archive, and that is the
     // case handled by this work-around.  The buttons for moving between tasks, and the whole
-    // task widget, will be disabled until signals connected to the onBodyMeshesAdded and
-    // onBodyMeshLoaded slots indicate that all the meshes from the archive have been loaded.
+    // task widget, will be disabled until signals connected to the onBodyRecycled,
+    // onBodyMeshesAdded abd onBodyMeshLoaded slots indicate that all the old meshes have been
+    // fully deleted and all the new meshes from the archive have been loaded.
 
+    m_bodyRecycledExpected = ZStackDocProxy::GetGeneralMeshList(m_body3dDoc).size();
+    m_bodyRecycledReceived = 0;
+
+    m_bodyMeshesAddedExpected = 0;
+    m_bodyMeshesAddedReceived = 0;
+
+    m_bodyMeshLoadedExpected = 0;
+    m_bodyMeshLoadedReceived = 0;
 
     const QSet<uint64_t> &visible = m_taskList[m_currentTaskIndex]->visibleBodies();
     foreach (uint64_t bodyID, visible) {
-        if (!ZFlyEmBody3dDoc::encodesTar(bodyID)) {
+        if (ZFlyEmBody3dDoc::encodesTar(bodyID)) {
+            m_bodyMeshesAddedExpected++;
+        } else {
             return;
         }
     }
 
     const QSet<uint64_t> &selected = m_taskList[m_currentTaskIndex]->selectedBodies();
     foreach (uint64_t bodyID, selected) {
-        if (!ZFlyEmBody3dDoc::encodesTar(bodyID)) {
-            return;
-        }
+      if (ZFlyEmBody3dDoc::encodesTar(bodyID)) {
+          m_bodyMeshesAddedExpected++;
+      } else {
+          return;
+      }
     }
 
     ui->nextButton->setEnabled(false);
     ui->prevButton->setEnabled(false);
     if (m_currentTaskWidget) {
-      m_currentTaskWidget->setEnabled(false);
+        m_currentTaskWidget->setEnabled(false);
     }
+    if (m_currentTaskMenuAction) {
+        m_currentTaskMenuAction->setEnabled(false);
+    }
+}
+
+void TaskProtocolWindow::enableButtonsAfterUpdating()
+{
+  if ((m_bodyRecycledExpected == m_bodyRecycledReceived) &&
+      (m_bodyMeshesAddedExpected == m_bodyMeshesAddedReceived) &&
+      (m_bodyMeshLoadedExpected == m_bodyMeshLoadedReceived)) {
+      updateButtonsEnabled();
+      if (m_currentTaskWidget) {
+          m_currentTaskWidget->setEnabled(true);
+      }
+      if (m_currentTaskMenuAction) {
+          m_currentTaskMenuAction->setEnabled(true);
+      }
+  }
 }
 
 /*
@@ -1094,24 +1125,21 @@ void TaskProtocolWindow::showInfo(QString title, QString message) {
 
 void TaskProtocolWindow::onBodyMeshesAdded(int numMeshes)
 {
+    m_bodyMeshesAddedReceived++;
     m_bodyMeshLoadedExpected += numMeshes;
-    if (m_bodyMeshLoadedExpected == m_bodyMeshLoadedReceived) {
-        updateButtonsEnabled();
-      if (m_currentTaskWidget) {
-        m_currentTaskWidget->setEnabled(true);
-      }
-    }
+    enableButtonsAfterUpdating();
 }
 
 void TaskProtocolWindow::onBodyMeshLoaded()
 {
     m_bodyMeshLoadedReceived++;
-    if (m_bodyMeshLoadedExpected == m_bodyMeshLoadedReceived) {
-        updateButtonsEnabled();
-        if (m_currentTaskWidget) {
-          m_currentTaskWidget->setEnabled(true);
-        }
-    }
+    enableButtonsAfterUpdating();
+}
+
+void TaskProtocolWindow::onBodyRecycled()
+{
+    m_bodyRecycledReceived++;
+    enableButtonsAfterUpdating();
 }
 
 void TaskProtocolWindow::applicationQuitting() {

--- a/neurolabi/gui/widgets/taskprotocolwindow.cpp
+++ b/neurolabi/gui/widgets/taskprotocolwindow.cpp
@@ -714,13 +714,15 @@ void TaskProtocolWindow::disableButtonsWhileUpdating()
     m_bodyMeshLoadedExpected = 0;
     m_bodyMeshLoadedReceived = 0;
 
-    // If the user triggers several calls to updateBodyWindow() in rapid succession by
-    // quickly moving between tasks, then the bodies loaded by one call may not be fully cleared
-    // by the next call, due to the way bodies are added and removed asynchronously in a background
+    // If the user triggers several calls to updateBodyWindow() in rapid succession, by
+    // quickly moving between tasks and using controls from the task widget that also change
+    // the loaded bodies, then the bodies loaded by one call may not be fully cleared by the
+    // next call, due to the way bodies are added and removed asynchronously in a background
     // thread.  The problem seems worst for meshes loaded from a tar archive, and that is the
-    // case handled by this work-around.  The buttons for moving between tasks will be disabled
-    // until signals connected to the onBodyMeshesAdded and onBodyMeshLoaded slots indicate that
-    // all the meshes from the archive have been loaded.
+    // case handled by this work-around.  The buttons for moving between tasks, and the whole
+    // task widget, will be disabled until signals connected to the onBodyMeshesAdded and
+    // onBodyMeshLoaded slots indicate that all the meshes from the archive have been loaded.
+
 
     const QSet<uint64_t> &visible = m_taskList[m_currentTaskIndex]->visibleBodies();
     foreach (uint64_t bodyID, visible) {
@@ -738,6 +740,9 @@ void TaskProtocolWindow::disableButtonsWhileUpdating()
 
     ui->nextButton->setEnabled(false);
     ui->prevButton->setEnabled(false);
+    if (m_currentTaskWidget) {
+      m_currentTaskWidget->setEnabled(false);
+    }
 }
 
 /*
@@ -1092,6 +1097,9 @@ void TaskProtocolWindow::onBodyMeshesAdded(int numMeshes)
     m_bodyMeshLoadedExpected += numMeshes;
     if (m_bodyMeshLoadedExpected == m_bodyMeshLoadedReceived) {
         updateButtonsEnabled();
+      if (m_currentTaskWidget) {
+        m_currentTaskWidget->setEnabled(true);
+      }
     }
 }
 
@@ -1100,6 +1108,9 @@ void TaskProtocolWindow::onBodyMeshLoaded()
     m_bodyMeshLoadedReceived++;
     if (m_bodyMeshLoadedExpected == m_bodyMeshLoadedReceived) {
         updateButtonsEnabled();
+        if (m_currentTaskWidget) {
+          m_currentTaskWidget->setEnabled(true);
+        }
     }
 }
 

--- a/neurolabi/gui/widgets/taskprotocolwindow.h
+++ b/neurolabi/gui/widgets/taskprotocolwindow.h
@@ -51,6 +51,8 @@ private slots:
     void onCompletedStateChanged(int state);
     void onReviewStateChanged(int state);
     void onShowCompletedStateChanged(int state);
+    void onBodyMeshesAdded(int numMeshes);
+    void onBodyMeshLoaded();
     void applicationQuitting();
 
 private:
@@ -114,6 +116,8 @@ private:
     bool m_nodeLocked;
     BodyPrefetchQueue * m_prefetchQueue;
     QThread * m_prefetchThread;
+    int m_bodyMeshLoadedExpected = 0;
+    int m_bodyMeshLoadedReceived = 0;
 
     void setWindowConfiguration(WindowConfigurations config);
     QJsonObject loadJsonFromFile(QString filepath);
@@ -135,6 +139,7 @@ private:
     void showInfo(QString title, QString message);
     void gotoCurrentTask();
     void updateBodyWindow();
+    void disableButtonsWhileUpdating();
     int getNext();
     int getNextUncompleted();
     int getPrev();

--- a/neurolabi/gui/widgets/taskprotocolwindow.h
+++ b/neurolabi/gui/widgets/taskprotocolwindow.h
@@ -53,6 +53,7 @@ private slots:
     void onShowCompletedStateChanged(int state);
     void onBodyMeshesAdded(int numMeshes);
     void onBodyMeshLoaded();
+    void onBodyRecycled();
     void applicationQuitting();
 
 private:
@@ -116,9 +117,12 @@ private:
     bool m_nodeLocked;
     BodyPrefetchQueue * m_prefetchQueue;
     QThread * m_prefetchThread;
+    int m_bodyRecycledExpected = 0;
+    int m_bodyRecycledReceived = 0;
+    int m_bodyMeshesAddedExpected = 0;
+    int m_bodyMeshesAddedReceived = 0;
     int m_bodyMeshLoadedExpected = 0;
     int m_bodyMeshLoadedReceived = 0;
-
     void setWindowConfiguration(WindowConfigurations config);
     QJsonObject loadJsonFromFile(QString filepath);
     void showError(QString title, QString message);
@@ -140,6 +144,7 @@ private:
     void gotoCurrentTask();
     void updateBodyWindow();
     void disableButtonsWhileUpdating();
+    void enableButtonsAfterUpdating();
     int getNext();
     int getNextUncompleted();
     int getPrev();


### PR DESCRIPTION
The protocol code now keeps track of the old meshes being recycled and the new meshes being loaded, and disables the task UI until recycling and loading is complete.  User testing indicates that this approach fixes the original bug:
https://github.com/janelia-flyem/NeuTu/issues/124