### PR TITLE
added "show grid" checkbox to synapse prediction protocol, region variation only

### DIFF
--- a/neurolabi/gui/protocols/synapsepredictionprotocol.cpp
+++ b/neurolabi/gui/protocols/synapsepredictionprotocol.cpp
@@ -72,6 +72,8 @@ SynapsePredictionProtocol::SynapsePredictionProtocol(QWidget *parent, std::strin
     connect(ui->sitesTableView, SIGNAL(doubleClicked(QModelIndex)),
             this, SLOT(onDoubleClickSitesTable(QModelIndex)));
 
+    connect(ui->gridCheckBox, SIGNAL(clicked(bool)), this, SLOT(onGridToggled()));
+
     // misc UI setup
     setupColorList();
 
@@ -107,6 +109,8 @@ const QString SynapsePredictionProtocol::MODE_PSD = "PSDs only";
 bool SynapsePredictionProtocol::initialize() {
 
     if (m_variation == VARIATION_REGION) {
+        ui->gridCheckBox->show();
+
         SynapsePredictionInputDialog inputDialog;
 
         inputDialog.setRoI("(RoI is ignored for now)");
@@ -125,6 +129,9 @@ bool SynapsePredictionProtocol::initialize() {
 //        m_protocolRange = volume;
 
     } else if (m_variation == VARIATION_BODY) {
+
+        // grid isn't used in this variation
+        ui->gridCheckBox->hide();
 
         SynapsePredictionBodyInputDialog inputDialog;
 
@@ -401,6 +408,17 @@ void SynapsePredictionProtocol::onModeChanged(QString item) {
     saveState();
 }
 
+void SynapsePredictionProtocol::onGridToggled() {
+    // note that we use emit rangeChanged(), which triggers the visual
+    //  grid update, and not setRange(), which also changes our local data;
+    //  when we hide the grid, we're not actually changing the protocol range
+    if (ui->gridCheckBox->isChecked()) {
+        emit rangeChanged(m_protocolRange.getFirstCorner(), m_protocolRange.getLastCorner());
+    } else {
+        emit rangeChanged(ZIntPoint(0, 0, 0), ZIntPoint(-1, -1, -1));
+    }
+}
+
 /*
  * is the synapse at the input point finished being reviewed under the current mode?
  */
@@ -527,7 +545,8 @@ void SynapsePredictionProtocol::loadDataRequested(ZJsonObject data) {
 
     // variation specific loading:
     if (m_variation == VARIATION_REGION) {
-      setRange(ZJsonArray(data.value(KEY_PROTOCOL_RANGE.c_str())));
+        ui->gridCheckBox->show();
+        setRange(ZJsonArray(data.value(KEY_PROTOCOL_RANGE.c_str())));
         if (!m_protocolRange.isEmpty()) {
             loadInitialSynapseList();
         } else {
@@ -535,6 +554,7 @@ void SynapsePredictionProtocol::loadDataRequested(ZJsonObject data) {
             return;
         }
     } else if (m_variation == VARIATION_BODY) {
+        ui->gridCheckBox->hide();
         m_subvariation = ZJsonParser::stringValue(data[KEY_SUBVARIATION.c_str()]);
         m_bodyID = ZJsonParser::integerValue(data[KEY_BODYID.c_str()]);
         loadInitialSynapseList();

--- a/neurolabi/gui/protocols/synapsepredictionprotocol.h
+++ b/neurolabi/gui/protocols/synapsepredictionprotocol.h
@@ -66,7 +66,8 @@ private slots:
     void onCompleteButton();
     void onRefreshButton();
     void onDoubleClickSitesTable(QModelIndex index);    
-    void onModeChanged(QString item);
+    void onModeChanged(QString item);    
+    void onGridToggled();
 
 private:
     static const std::string KEY_VARIATION;

--- a/neurolabi/gui/protocols/synapsepredictionprotocol.ui
+++ b/neurolabi/gui/protocols/synapsepredictionprotocol.ui
@@ -288,6 +288,16 @@
       </spacer>
      </item>
      <item>
+      <widget class="QCheckBox" name="gridCheckBox">
+       <property name="text">
+        <string>Show grid</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="refreshButton">
        <property name="text">
         <string>Refresh data</string>


### PR DESCRIPTION
* added "show grid" check box to synapse prediction protocol (next to refresh data button)
* only appears if you're doing the "region" variation (grid not needed when annotating T-bars on a body)
