### PR TITLE
conda recipes: Update libdvid-cpp/lowtis requirements to latest versions

### DIFF
--- a/recipe-neu3-develop/meta.yaml
+++ b/recipe-neu3-develop/meta.yaml
@@ -23,13 +23,13 @@ requirements:
   build:
     - python >=3.6
     - qt      5*
-    - libdvid-cpp >=0.2.post55
+    - libdvid-cpp >=0.3.post52
     - fftw    3.3*
     - jansson 2.7
     - libpng  1.6*
     - hdf5    1.8*
     - pango   1.40* # [linux64]
-    - lowtis  >=0.1.0.p
+    - lowtis  >=0.1.0.post58
     - cmake
     - ninja
     - tbb
@@ -41,13 +41,13 @@ requirements:
   run:
     - python >=3.6
     - qt      5*
-    - libdvid-cpp >=0.2.post55
+    - libdvid-cpp >=0.3.post52
     - fftw    3.3*
     - jansson 2.7
     - libpng  1.6*
     - hdf5    1.8*
     - pango   1.40* # [linux64]
-    - lowtis  >=0.1.0.p
+    - lowtis  >=0.1.0.post58
     - ninja
     - tbb
     - vtk 7.1*

--- a/recipe-neutu-develop/meta.yaml
+++ b/recipe-neutu-develop/meta.yaml
@@ -27,13 +27,13 @@ requirements:
   build:
     - python >=3.6
     - qt      5*
-    - libdvid-cpp >=0.2.post55
+    - libdvid-cpp >=0.3.post52
     - fftw    3.3*
     - jansson 2.7
     - libpng  1.6*
     - hdf5    1.8*
     - pango   1.40* # [linux64]
-    - lowtis  >=0.1.0.p
+    - lowtis  >=0.1.0.post58
     - cmake
     - ninja
     - tbb
@@ -45,13 +45,13 @@ requirements:
   run:
     - python >=3.6
     - qt      5*
-    - libdvid-cpp >=0.2.post55
+    - libdvid-cpp >=0.3.post52
     - fftw    3.3*
     - jansson 2.7
     - libpng  1.6*
     - hdf5    1.8*
     - pango   1.40* # [linux64]
-    - lowtis  >=0.1.0.p
+    - lowtis  >=0.1.0.post58
     - ninja
     - tbb
     - vtk 7.1*

--- a/recipe-neutu/meta.yaml
+++ b/recipe-neutu/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - libpng  1.6*
     - hdf5    1.8*
     - pango   1.40* # [linux64]
-    - lowtis  0.1.0.post55
+    - lowtis  >=0.1.0.post58
     - cmake
     - ninja
     - tbb
@@ -50,7 +50,7 @@ requirements:
     - libpng  1.6*
     - hdf5    1.8*
     - pango   1.40* # [linux64]
-    - lowtis  >=0.1.0.post57,<0.1.0.post58
+    - lowtis  >=0.1.0.post58
     - ninja
     - tbb
     - vtk 7.1*

--- a/recipe-neutube-python-debug/meta.yaml
+++ b/recipe-neutube-python-debug/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - python >=2.7
     - python {{PY_VER}}*
     - swig
-    - libdvid-cpp >=0.2.post55
+    - libdvid-cpp >=0.3.post52
     - fftw    3.3*
     - jansson 2.7
     - libxml2 2.9*
@@ -29,7 +29,7 @@ requirements:
 
   run:
     - python {{PY_VER}}*
-    - libdvid-cpp >=0.2.post55
+    - libdvid-cpp >=0.3.post52
     - fftw    3.3*
     - jansson 2.7
     - libxml2 2.9*

--- a/recipe-neutube-python/meta.yaml
+++ b/recipe-neutube-python/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - python >=3.6
     - python {{PY_VER}}*
     - swig
-    - libdvid-cpp >=0.3
+    - libdvid-cpp >=0.3.post52
     - fftw    3.3*
     - jansson 2.7
     - libxml2 2.9*
@@ -30,7 +30,7 @@ requirements:
 
   run:
     - python {{PY_VER}}*
-    - libdvid-cpp >=0.3
+    - libdvid-cpp >=0.3.post52
     - fftw    3.3*
     - jansson 2.7
     - libxml2 2.9*


### PR DESCRIPTION
I recently fixed a small bug in `libdvid-cpp`.  This PR updates the NeuTu recipes to use latest versions of `libdvid-cpp` and `lowtis`.  (I just published new conda packages for both.)

---

**Side note:** If you haven't done so recently, I recommend updating to the most recent versions of `conda` and `conda-build`:

```
conda update -n base conda conda-build
```
