### PR TITLE
Fixes mapping of supervoxels to bodies for 'tarsupervoxels'.

### DIFF
--- a/neurolabi/gui/flyem/zflyembody3ddoc.cpp
+++ b/neurolabi/gui/flyem/zflyembody3ddoc.cpp
@@ -3152,6 +3152,8 @@ std::vector<ZMesh*> ZFlyEmBody3dDoc::makeTarMeshModels(
   const float PROGRESS_FRACTION_START = 1 / 3.0;
   emit meshArchiveLoadingProgress(PROGRESS_FRACTION_START);
 
+  bool isSupervoxelTar = ZFlyEmBodyManager::encodingSupervoxelTar(bodyId);
+
   // For now, use the new "tarsupervoxels" data instance for tar archives of meshes
   // only if an environment variable is set,  When testing is complete, this approach
   // will become the default.
@@ -3175,7 +3177,6 @@ std::vector<ZMesh*> ZFlyEmBody3dDoc::makeTarMeshModels(
     reader.readMeshArchiveAsync(arc, resultVec, progress);
     //      QSet<uint64_t> mappedSet;
     uint64_t decodedBodyId = decode(bodyId);
-    bool isSupervoxelTar = ZFlyEmBodyManager::encodingSupervoxelTar(bodyId);
     for (ZMesh *mesh : resultVec) {
       finalizeMesh(mesh, decodedBodyId, 0, t);
       if (isSupervoxelTar) {


### PR DESCRIPTION
Without this change, setting "todos" won't work for supervoxels loaded from a "tarsupervoxels" instance.  The "z1" release should be rebuilt with this change before proofreaders start trying to do cleaving with "tarsupervoxels".