### PR TITLE
Compatibility with flyem-build-container

### DIFF
--- a/recipe-neutu/build.sh
+++ b/recipe-neutu/build.sh
@@ -7,6 +7,7 @@ else
     # Create a symlink for build scripts that expect that name.
     cd $(dirname ${CC}) && ln -s $(basename ${CC}) gcc && cd -
     cd $(dirname ${CXX}) && ln -s $(basename ${CXX}) g++ && cd -
+    cd $(dirname ${LD}) && ln -s $(basename ${LD}) ld && cd -
 fi
 
 if [ $(uname) == 'Darwin' ]; then

--- a/recipe-neutu/build.sh
+++ b/recipe-neutu/build.sh
@@ -64,7 +64,7 @@ then
   edition=neu3
 fi
 
-bash -x -e build.sh ${PREFIX}/bin/qmake ${QMAKE_SPEC_PATH} -e $edition $build_flag -q 'LIBS+=-Wl,-rpath-link,/usr/lib64 LIBS+=-Wl,-rpath-link,/lib64 LIBS+=-L/usr/lib64 INCLUDEPATH+=/usr/include'
+bash -x -e build.sh ${PREFIX}/bin/qmake ${QMAKE_SPEC_PATH} -e $edition $build_flag -q 'LIBS+=-Wl,-rpath-link,/usr/lib64 LIBS+=-Wl,-rpath-link,/lib64 LIBS+=-L/usr/lib64 INCLUDEPATH+=/usr/include DEFINES+=_GLIBCXX_USE_CXX11_ABI=0'
 
 # Install to conda environment
 if [ $(uname) == 'Darwin' ]; then

--- a/recipe-neutu/build.sh
+++ b/recipe-neutu/build.sh
@@ -1,6 +1,12 @@
 if [ $(uname) == 'Darwin' ]; then
     CC=/usr/bin/cc
     CXX=/usr/bin/clang
+else
+    # conda is providing gcc and defining $CC,
+    # but the binary isn't named 'gcc'.
+    # Create a symlink for build scripts that expect that name.
+    cd $(dirname ${CC}) && ln -s $(basename ${CC}) gcc && cd -
+    cd $(dirname ${CXX}) && ln -s $(basename ${CXX}) g++ && cd -
 fi
 
 if [ $(uname) == 'Darwin' ]; then
@@ -58,7 +64,7 @@ then
   edition=neu3
 fi
 
-bash -x -e build.sh ${PREFIX}/bin/qmake ${QMAKE_SPEC_PATH} -e $edition $build_flag
+bash -x -e build.sh ${PREFIX}/bin/qmake ${QMAKE_SPEC_PATH} -e $edition $build_flag -q 'LIBS+=-Wl,-rpath-link,/usr/lib64 LIBS+=-Wl,-rpath-link,/lib64 LIBS+=-L/usr/lib64 INCLUDEPATH+=/usr/include'
 
 # Install to conda environment
 if [ $(uname) == 'Darwin' ]; then


### PR DESCRIPTION
Here are the changes Ting and I made to get NeuTu building in the `flyem/flyem-build` docker container.

**Note:** Now the build succeeds, but I haven't actually tested it on a Linux machine yet.  Someone should give my new build a try before merging this PR:

```
conda install -c stuarteberg neutu-develop=0.1.post1781
```

Side note: I'm not sure if it would be better to put these changes within a `.pro` file somewhere, rather than using the `-q` option in `build.sh`.  I'll let you decide that.

Also: The `flyem-build` docker container was missing two packages, so I've added them to the Dockerfile.  You should pull the latest version of the docker image, or simply install them yourself when you attach to your container:

```
sudo yum install -y libGLU-devel libXi
```
