### PR TITLE
Fixes disabled UI when focused-merging tasks share a body.

### DIFF
--- a/neurolabi/gui/widgets/taskprotocolwindow.cpp
+++ b/neurolabi/gui/widgets/taskprotocolwindow.cpp
@@ -971,6 +971,7 @@ void TaskProtocolWindow::disableButtonsWhileUpdating(const QSet<uint64_t> &toRem
     m_bodyMeshesAddedExpected = 0;
     m_bodyMeshesAddedReceived = 0;
 
+    m_bodyMeshLoadedExpected = 0;
     bool usingTars = false;
     foreach (uint64_t bodyID, visibleOrSelected) {
         if (ZFlyEmBodyManager::encodesTar(bodyID)) {
@@ -981,13 +982,14 @@ void TaskProtocolWindow::disableButtonsWhileUpdating(const QSet<uint64_t> &toRem
 
                 m_bodyMeshesAddedExpected++;
             }
-        }
-    }
+        } else {
+          if (!toRemove.contains(bodyID)) {
 
-    if (usingTars) {
-        m_bodyMeshLoadedExpected = 0;
-    } else {
-        m_bodyMeshLoadedExpected = (visible + selected).size();
+              // Only if an added body was not just removed should the expected count change.
+
+              m_bodyMeshLoadedExpected++;
+          }
+        }
     }
 
     m_bodyMeshLoadedReceived = 0;


### PR DESCRIPTION
Tested on one of the new "tip detection" focused-merging assignments, in which all the tasks share one body.  Also tested on a merge-review assignment in which tasks also share a body, and there was no regression.