### PR TITLE
Tip detection

### DIFF
--- a/neurolabi/gui/dialogs/flyemtododialog.ui
+++ b/neurolabi/gui/dialogs/flyemtododialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>700</width>
+    <width>1000</width>
     <height>550</height>
    </rect>
   </property>

--- a/neurolabi/gui/flyem/zflyemproofdoc.cpp
+++ b/neurolabi/gui/flyem/zflyemproofdoc.cpp
@@ -4,6 +4,7 @@
 #include <QList>
 #include <QTimer>
 #include <QDir>
+#include <QDateTime>
 #include <QtConcurrentRun>
 #include <QMessageBox>
 #include <QElapsedTimer>
@@ -2043,6 +2044,8 @@ void ZFlyEmProofDoc::setTodoItemChecked(int x, int y, int z, bool checking)
     if (item.isValid()) {
       if (checking != item.isChecked()) {
         item.setChecked(checking);
+        item.addProperty("checked updated by", neutu::GetCurrentUserName());
+        item.addProperty("checked updated at", QDateTime::currentDateTime().toString("yyyy-MM-dd hh:mm:ss").toStdString());
         td->addItem(item, ZFlyEmToDoList::DATA_GLOBAL);
         bufferObjectModified(td);
         modified = true;

--- a/neurolabi/gui/flyem/zflyemtodopresenter.cpp
+++ b/neurolabi/gui/flyem/zflyemtodopresenter.cpp
@@ -6,8 +6,11 @@ ZFlyEmTodoPresenter::ZFlyEmTodoPresenter()
 {
   // keep this in sync with the TodoTableColumns enum in .h!
   m_fieldList << " Body ID " << "Action" << "Comment" << "Priority"
-              << "  Z   " << "  X  " << "  Y  " << "  User  ";
+              << "  Z   " << "  X  " << "  Y  " << "tip index" << "tip RoI" << "  User  ";
 }
+
+const std::string ZFlyEmTodoPresenter::KEY_TIPQC_ROI = "tip qc roi";
+const std::string ZFlyEmTodoPresenter::KEY_TIPQC_INDEX = "tip qc index";
 
 void ZFlyEmTodoPresenter::setVisibleTest(
     std::function<bool (const ZFlyEmToDoItem &)> f)
@@ -41,6 +44,10 @@ QVariant ZFlyEmTodoPresenter::data(
         return item.getPosition().getX();
       case TODO_Y_COLUMN:
         return item.getPosition().getY();
+      case TODO_TIP_INDEX_COLUMN:
+        return getTipIndex(item);
+      case TODO_TIP_ROI_COLUMN:
+        return getTipRoi(item);
       case TODO_USERNAME_COLUMN:
         return item.getUserName().c_str();
       }
@@ -64,4 +71,24 @@ QVariant ZFlyEmTodoPresenter::data(
   }
 
   return QVariant();
+}
+
+QVariant ZFlyEmTodoPresenter::getTipIndex(const ZFlyEmToDoItem &item) const {
+  if (item.hasProperty(KEY_TIPQC_INDEX)) {
+    std::string s = item.getProperty<std::string>(KEY_TIPQC_INDEX);
+    return std::stoi(s);
+  } else {
+    // we want no index to be nothing, not 0 or -1 or anything
+    return QVariant();
+  }
+}
+
+QString ZFlyEmTodoPresenter::getTipRoi(const ZFlyEmToDoItem &item) const {
+  // if the to do item was placed by the tip detector and has an RoI,
+  //  return it
+  QString roi;
+  if (item.hasProperty(KEY_TIPQC_ROI)) {
+    roi = QString::fromStdString(item.getProperty<std::string>(KEY_TIPQC_ROI));
+  }
+  return roi;
 }

--- a/neurolabi/gui/flyem/zflyemtodopresenter.h
+++ b/neurolabi/gui/flyem/zflyemtodopresenter.h
@@ -21,6 +21,8 @@ public:
     TODO_Z_COLUMN,
     TODO_X_COLUMN,
     TODO_Y_COLUMN,
+    TODO_TIP_INDEX_COLUMN,
+    TODO_TIP_ROI_COLUMN,
     TODO_USERNAME_COLUMN
   };
 
@@ -32,8 +34,12 @@ public:
   void setVisibleTest(std::function<bool(const ZFlyEmToDoItem&)> f);
 
 private:
+  static const std::string KEY_TIPQC_INDEX;
+  static const std::string KEY_TIPQC_ROI;
   std::function<bool(const ZFlyEmToDoItem&)> m_visible =
-      [](const ZFlyEmToDoItem&) {return true;};
+          [](const ZFlyEmToDoItem&) {return true;};
+  QString getTipRoi(const ZFlyEmToDoItem &item) const;
+  QVariant getTipIndex(const ZFlyEmToDoItem &item) const;
 };
 
 #endif // ZFLYEMTODOPRESENTER_H


### PR DESCRIPTION
These changes are in support of Steve's new tip detection QC scheme.

First, added two columns to the to do table: tip index and tip RoI. This is unfortunately kind of ugly. When this tip QC workflow is run, Stuart will add two properties to a tip detector to do item, "tip qc index" and "tip qc roi". If they are present, they will be displayed in these two new columns in the table. The user can then sort and filter on them to review whether the tips have been correctly followed or whatever. The index is the order in which they should examine the tips. I don't like this because those columns are unused for all other to do items. Maybe later we will take them back out, after this task is done. I think all of this code is in ZFlyEmTodoPresenter.

Second change: in ZFlyEmProofDoc::setTodoItemChecked(), record the username and timestamp whenever a to do "checked" status is changed. Store them in two new properties on the to do item: "checked updated by" and "checked updated at". This will help Stuart measure how fast the user completes the task.

I'm on vacation next week, but hopefully these are straightforward changes that won't cause problems.