### PR TITLE
conda-recipe: Pin gcc to 7.5.0

### DIFF
--- a/recipe-neutu/conda_build_config.yaml
+++ b/recipe-neutu/conda_build_config.yaml
@@ -1,0 +1,4 @@
+cxx_compiler_version:  # [linux]
+  - 7.5.0              # [linux]
+c_compiler_version:    # [linux]
+  - 7.5.0              # [linux]

--- a/recipe-neutu/meta.yaml
+++ b/recipe-neutu/meta.yaml
@@ -24,9 +24,7 @@ build:
 
 requirements:
   build:
-    - gxx_linux-64 7.3.0 # [linux]
-    - binutils_linux-64 2.34 hc952b39_18 # [linux]
-    - binutils_impl_linux-64 2.34 h53a641e_0 # [linux]
+    - {{ compiler('cxx') }} # [linux]
     - cmake
 
   host:


### PR DESCRIPTION
This PR pins the compiler version via line in the recipe's `conda_build_config.yaml`.

### Background:

Yesterday @tingzhao had trouble getting NeuTu to compile in our [docker container][1] due to a mysterious error:

```
/tmp/ccpjQ535.s: Assembler messages:
/tmp/ccpjQ535.s:3575: Error: expecting string instruction after `rep'
/tmp/ccpjQ535.s:3610: Error: expecting string instruction after `rep'
/tmp/ccpjQ535.s:3614: Error: expecting string instruction after `rep'
/tmp/ccpjQ535.s:5369: Error: expecting string instruction after `rep'
/tmp/ccpjQ535.s:5396: Error: expecting string instruction after `rep'
```

We determined the problem to be with a recent upgrade to `binutils_impl_linux-64` in conda-forge.  We fixed the issue by explicitly downgrading gcc and binutils.

But in the mean time, conda-forge has fixed the broken binutils package.  We can upgrade to gcc 7.5.0 again (I tested it).  While we're at it, we should also pin the version of gcc so we don't get surprised if they upgrade the default compiler.

[1]: https://github.com/janelia-flyem/flyem-build-container/