### PR TITLE
conda-recipe: Update tbb, librdkafka, libiconv

### DIFF
--- a/recipe-neutu/meta.yaml
+++ b/recipe-neutu/meta.yaml
@@ -26,56 +26,55 @@ requirements:
   build:
     - {{ compiler('cxx') }} # [linux]
     - cmake
+    - ninja 1.7.2*
 
   host:
     - libneucore >=0.1.4, <2.0
-    - qt      5.9*
-    - fftw    3.3*
-    - jansson 2.7*
-    - libpng  1.6*
-    - hdf5    1.10*
-    - pango   1.40* # [linux64]
-    - lowtis  0.1.0.post75*
-    - cmake
-    - ninja 1.7.2*
-    - tbb 2019.4*
-    - tbb-devel 2019.4*
+    - qt      5.9.*
+    - fftw    3.3.*
+    - jansson 2.7.*
+    - libpng  1.6.*
+    - hdf5    1.10.*
+    - pango   1.40.*         # [linux64]
+    - lowtis  0.1.0.post75.*
+    - tbb 2019.9.*
+    - tbb-devel 2019.9.*
     - vtk 8.2.*
-    - assimp 4.0.1*
-    - glbinding 2.1.3*
-    - draco 1.3.4*
-    - libarchive 3.3.3*
-    - libiconv 1.15*
-    - librdkafka 1.0.1*
-    - alsa-lib 1.1.5* # [linux64]
-    - xorg-libxrandr 1.5.1* # [linux64]
-    - xorg-libxcursor 1.2.0* # [linux64]
-    - xorg-libxtst 1.2.3* # [linux64]
+    - assimp 4.0.1.*
+    - glbinding 2.1.3.*
+    - draco 1.3.4.*
+    - libarchive 3.3.3.*
+    - libiconv 1.16.*
+    - librdkafka 1.3*
+    - alsa-lib 1.1.5.*         # [linux64]
+    - xorg-libxrandr 1.5.1.*   # [linux64]
+    - xorg-libxcursor 1.2.0.*  # [linux64]
+    - xorg-libxtst 1.2.3.*     # [linux64]
 
   run:
     - libneucore >=0.1.4, <2.0
-    - python  3.7.3*
-    - qt      5.9*
-    - fftw    3.3*
-    - jansson 2.7*
-    - libpng  1.6*
-    - hdf5    1.10*
-    - pango   1.40* # [linux64]
-    - lowtis  0.1.0.post75*
-    - tbb 2019.4*
-    - tbb-devel 2019.4*
+    - python  3.7.*
+    - qt      5.9.*
+    - fftw    3.3.*
+    - jansson 2.7.*
+    - libpng  1.6.*
+    - hdf5    1.10.*
+    - pango   1.40.*         # [linux64]
+    - lowtis  0.1.0.post75.*
+    - tbb 2019.9.*
+    - tbb-devel 2019.9.*
     - vtk 8.2.*
-    - assimp 4.0.1*
-    - glbinding 2.1.3*
-    - draco 1.3.4*
-    - libarchive 3.3.3*
-    - libiconv 1.15*
-    - librdkafka 1.0.1*
-    - alsa-lib 1.1.5* # [linux64]
-    - xorg-libxrandr 1.5.1* # [linux64]
-    - xorg-libxcursor 1.2.0* # [linux64]
-    - xorg-libxtst 1.2.3* # [linux64]
-    - marktips 0.3*
+    - assimp 4.0.1.*
+    - glbinding 2.1.3.*
+    - draco 1.3.4.*
+    - libarchive 3.3.3.*
+    - libiconv 1.16.*
+    - librdkafka 1.3*
+    - alsa-lib 1.1.5.*         # [linux64]
+    - xorg-libxrandr 1.5.1.*   # [linux64]
+    - xorg-libxcursor 1.2.0.*  # [linux64]
+    - xorg-libxtst 1.2.3.*     # [linux64]
+    - marktips 0.3.*
 
 about:
   home: http://github.com/janelia-flyem/NeuTu


### PR DESCRIPTION
Also minor tweaks to meta.yaml to eliminate warnings from conda.

With these changes, NeuTu can build on Mac again, using lowtis `0.1.0.post75`.