### PR TITLE
conda-recipe: Update pango and tbb

### DIFF
--- a/recipe-neutu/meta.yaml
+++ b/recipe-neutu/meta.yaml
@@ -35,46 +35,50 @@ requirements:
     - jansson 2.7.*
     - libpng  1.6.*
     - hdf5    1.10.*
-    - pango   1.40.*         # [linux64]
+    - pango   1.42.*         # [linux64]
     - lowtis  0.1.0.post75.*
-    - tbb 2019.9.*
-    - tbb-devel 2019.9.*
+    - tbb 2020.2.*
+    - tbb-devel 2020.2.*
     - vtk 8.2.*
     - assimp 4.0.1.*
     - glbinding 2.1.3.*
     - draco 1.3.4.*
     - libarchive 3.3.3.*
     - libiconv 1.16.*
-    - librdkafka 1.3*
+    - librdkafka 1.3.*
     - alsa-lib 1.1.5.*         # [linux64]
     - xorg-libxrandr 1.5.1.*   # [linux64]
     - xorg-libxcursor 1.2.0.*  # [linux64]
     - xorg-libxtst 1.2.3.*     # [linux64]
 
   run:
-    - libneucore >=0.1.4, <2.0
+    # runtime only
     - python  3.7.*
+    - marktips 0.3.*
+
+    # copied from host (above)
+    - libneucore >=0.1.4, <2.0
     - qt      5.9.*
     - fftw    3.3.*
     - jansson 2.7.*
     - libpng  1.6.*
     - hdf5    1.10.*
-    - pango   1.40.*         # [linux64]
+    - pango   1.42.*         # [linux64]
     - lowtis  0.1.0.post75.*
-    - tbb 2019.9.*
-    - tbb-devel 2019.9.*
+    - tbb 2020.2.*
+    - tbb-devel 2020.2.*
     - vtk 8.2.*
     - assimp 4.0.1.*
     - glbinding 2.1.3.*
     - draco 1.3.4.*
     - libarchive 3.3.3.*
     - libiconv 1.16.*
-    - librdkafka 1.3*
+    - librdkafka 1.3.*
     - alsa-lib 1.1.5.*         # [linux64]
     - xorg-libxrandr 1.5.1.*   # [linux64]
     - xorg-libxcursor 1.2.0.*  # [linux64]
     - xorg-libxtst 1.2.3.*     # [linux64]
-    - marktips 0.3.*
+    
 
 about:
   home: http://github.com/janelia-flyem/NeuTu


### PR DESCRIPTION
With these changes, I can build on Mac and Linux. (I checked both this time.)

BTW, the reason updating `lowtis` has triggered all of these other upgrades is that last month I upgraded several of `libdvid-cpp`'s requirements to match what `conda-forge` is using these days.  It's a minor hassle, but it's good (for me, anyway) to be reasonably in-sync with `conda-forge`.