### PR TITLE
recipe-neutu: Update fftw requirement to avoid MacOS dyld error

### DIFF
--- a/recipe-neutu/meta.yaml
+++ b/recipe-neutu/meta.yaml
@@ -31,7 +31,7 @@ requirements:
   host:
     - libneucore >=0.1.4, <2.0
     - qt      5.9.*
-    - fftw    3.3.*
+    - fftw    >=3.3.9
     - jansson 2.7.*
     - libpng  1.6.*
     - hdf5    1.10.*
@@ -59,7 +59,7 @@ requirements:
     # copied from host (above)
     - libneucore >=0.1.4, <2.0
     - qt      5.9.*
-    - fftw    3.3.*
+    - fftw    >=3.3.9
     - jansson 2.7.*
     - libpng  1.6.*
     - hdf5    1.10.*


### PR DESCRIPTION
Apparently the most recent `neu3` binary was built with `fftw 3.3.9`, which means you can't use it in an environment with `fftw 3.3.8`.  On Mac, I see the following error:

```
$ neu3
dyld: Library not loaded: @rpath/libfftw3.3.dylib
  Referenced from: /opt/miniconda/envs/neu3/bin/neu3.app/Contents/MacOS/neu3
  Reason: Incompatible library version: neu3 requires version 10.0.0 or later, but libfftw3.3.dylib provides version 9.0.0
[1]    47401 abort      /opt/miniconda/envs/neu3/bin/neu3.app/Contents/MacOS/neu3
```

I can fix the error by upgrading to `fftw 3.3.9` in my environment, so maybe this tweak to the recipe will avoid this error next time.