### PR TITLE
Update dependencies (Qt-5.12 and VTK-9.0)

### DIFF
--- a/neurolabi/gui/extlib.pri
+++ b/neurolabi/gui/extlib.pri
@@ -149,7 +149,7 @@ contains(DEFINES, _ENABLE_SURFRECON_) {
 #  QMAKE_CXXFLAGS+=-fext-numeric-literals
 }
 
-VTK_VER = 8.2
+VTK_VER = 9.0
 
 #
 exists($${CONDA_ENV}) {

--- a/neurolabi/gui/misc/zvtkutil.cpp
+++ b/neurolabi/gui/misc/zvtkutil.cpp
@@ -33,7 +33,7 @@ ZMesh vtkPolyDataToMesh(vtkPolyData* polyData)
     }
   }
   vtkIdType npts;
-  vtkIdType* pts;
+  vtkIdType const * pts;
   polys->InitTraversal();
   for (int i = 0; i < polyData->GetNumberOfPolys(); ++i) {
     int h = polys->GetNextCell(npts, pts);

--- a/neurolabi/gui/protocols/todoreviewinputdialog.cpp
+++ b/neurolabi/gui/protocols/todoreviewinputdialog.cpp
@@ -2,6 +2,8 @@
 #include "ui_todoreviewinputdialog.h"
 
 #include <QMessageBox>
+#include <QRegularExpression>
+#include <QRegularExpressionValidator>
 
 ToDoReviewInputDialog::ToDoReviewInputDialog(QWidget *parent) :
     QDialog(parent),

--- a/recipe-neutu/meta.yaml
+++ b/recipe-neutu/meta.yaml
@@ -31,22 +31,22 @@ requirements:
   host:
     - libneucore >=0.1.4, <2.0
     - libneumath >=0.1.0, <2.0
-    - qt      5.9.*
+    - qt      5.12.*
     - fftw    >=3.3.9, <3.4
     - jansson 2.7.*
     - libpng  1.6.*
     - hdf5    1.10.*
     - pango   1.42.*         # [linux64]
-    - lowtis  0.1.0.post75.*
+    - lowtis  0.1.0.post76.*
     - tbb 2020.2.*
     - tbb-devel 2020.2.*
-    - vtk 8.2.*
+    - vtk 9.0.*
     - assimp 4.0.1.*
     - glbinding 2.1.3.*
     - draco 1.3.4.*
-    - libarchive 3.3.3.*
+    - libarchive 3.5.1.*
     - libiconv 1.16.*
-    - librdkafka 1.3.*
+    - librdkafka 1.6.*
     - alsa-lib 1.1.5.*         # [linux64]
     - xorg-libxrandr 1.5.1.*   # [linux64]
     - xorg-libxcursor 1.2.0.*  # [linux64]
@@ -60,22 +60,22 @@ requirements:
     # copied from host (above)
     - libneucore >=0.1.4, <2.0
     - libneumath >=0.1.0, <2.0
-    - qt      5.9.*
+    - qt      5.12.*
     - fftw    >=3.3.9, <3.4
     - jansson 2.7.*
     - libpng  1.6.*
     - hdf5    1.10.*
     - pango   1.42.*         # [linux64]
-    - lowtis  0.1.0.post75.*
+    - lowtis  0.1.0.post76.*
     - tbb 2020.2.*
     - tbb-devel 2020.2.*
-    - vtk 8.2.*
+    - vtk 9.0.*
     - assimp 4.0.1.*
     - glbinding 2.1.3.*
     - draco 1.3.4.*
-    - libarchive 3.3.3.*
+    - libarchive 3.5.1.*
     - libiconv 1.16.*
-    - librdkafka 1.3.*
+    - librdkafka 1.6.*
     - alsa-lib 1.1.5.*         # [linux64]
     - xorg-libxrandr 1.5.1.*   # [linux64]
     - xorg-libxcursor 1.2.0.*  # [linux64]


### PR DESCRIPTION
This PR updates NeuTu's dependencies to be compatible with recent versions of the conda-forge stack.  In particular, it updates to Qt-5.12 and VTK-9.0.  Only minor changes were needed to get the build to compile on my Mac.  I haven't tested the resulting binary.

Note: I did not update the linux-only dependencies or attempt a linux build.  You should probably make the following additional changes:

```yaml
- pango 1.42.*      # [linux64]
- alsa-lib 1.2.3.*  # [linux64]
```