### PR TITLE
Fix build qt 5.12

### DIFF
--- a/recipe-neutu/meta.yaml
+++ b/recipe-neutu/meta.yaml
@@ -14,6 +14,8 @@ package:
 
 source:
     git_url: ../
+    patches:
+      - patches/libgl-is-in-build-prefix.patch
 
 build:
   number: 0

--- a/recipe-neutu/meta.yaml
+++ b/recipe-neutu/meta.yaml
@@ -24,9 +24,12 @@ build:
 
 requirements:
   build:
-    - {{ compiler('cxx') }} # [linux]
     - cmake
     - ninja 1.7.2*
+    - {{ compiler('cxx') }} # [linux]
+    - {{ cdt('mesa-libgl-devel') }}  # [linux]
+    - {{ cdt('mesa-libegl-devel') }}  # [linux]
+    - {{ cdt('mesa-dri-drivers') }}  # [linux]
 
   host:
     - libneucore >=0.1.4, <2.0

--- a/recipe-neutu/patches/libgl-is-in-build-prefix.patch
+++ b/recipe-neutu/patches/libgl-is-in-build-prefix.patch
@@ -1,0 +1,13 @@
+diff --git neurolabi/gui/gui.pro neurolabi/gui/gui.pro
+index 5d064f6e4..1d0ec52c8 100644
+--- neurolabi/gui/gui.pro
++++ neurolabi/gui/gui.pro
+@@ -54,6 +54,8 @@ win32 {
+     }
+ }
+ 
++QMAKE_LIBS_OPENGL = $$(BUILD_PREFIX)/$$(HOST)/sysroot/usr/lib64/libGL.so
++
+ unix {
+   DEFINES += _UNIX_
+ }


### PR DESCRIPTION
This fixes the `libGL.so: No such file or directory` error in the linux build.

It's related to a problem in the Qt feedstock, which [I've reported here.][1]

[1]: https://github.com/conda-forge/qt-main-feedstock/issues/123